### PR TITLE
Add FIR copy to S3, ignore any failures

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -16,3 +16,11 @@ aws s3 sync $EXCLUDES _site s3://datalab-staging-usaspending-gov --delete
 elif [[ $TRAVIS_BRANCH == 'dev'      ]]; then
 aws s3 sync $EXCLUDES _site s3://datalab-dev-usaspending-gov --delete
 fi
+
+# FIR Copies (uses same aws region)
+aws configure set aws_access_key_id $FIR_ACCESS_KEY_ID
+aws configure set aws_secret_access_key $FIR_SECRET_ACCESS_KEY
+
+if [[ $TRAVIS_BRANCH == 'dev'     ]]; then
+aws s3 sync $EXCLUDES _site s3://fir-public-datalab-dev --delete || true
+fi


### PR DESCRIPTION
The FIR team is still working with permissions for this copy. We ignore the failures of this copy because 1) FIR is in prototype and 2) FIR team is fixing access issues between Travis and the bucket, but we can say we covered the copy portion and it's been automated.