### PR TITLE
DA-3694

### DIFF
--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -8,8 +8,8 @@
         },
         "image": "{{ '/assets/data-lab-og.png' | prepend: site.baseurl | prepend: site.url }}",
         "headline": "{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% endif %}",
-        "datePublished": "2019-01-17T08:00:00+06:00",
-        "dateModified": "2019-01-17T08:00:00+06:00",
+        "datePublished": "{% if page.datePublished %}{{ page.datePublished }}{% else %}2019-04-09T08:00:00+06:00{% endif %}",
+        "dateModified": "{% if page.dateModified %}{{ page.dateModified }}{% else %}2019-04-09T08:00:00+06:00{% endif %}",
         "author": {
         "@type": "Organization",
         "name": "U.S. Treasury",

--- a/entries/contract-explorer.html
+++ b/entries/contract-explorer.html
@@ -10,6 +10,7 @@ banner: landings/contracts.jpg
 alt: Contract Explorer-Photography by Franz Harvin Aceituna
 permalink: contract-explorer.html
 category: entry
+datePublished: 2019-04-08T08:00:00+06:00
 ---
 
 <style>


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-3694

Well, not technically dynamic, but allows each page to have it's own values instead of a site-wide one (which are fallbacks). Contract Explorer page is example of page-level override (also to prove it works both ways). Confirmed with https://search.google.com/structured-data/testing-tool