### PR TITLE
Dev release build fix

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -20,7 +20,7 @@ if [[ $TRAVIS_BRANCH == 'master'     ]]; then
 aws s3 sync $EXCLUDES _site s3://datalab-usaspending-gov --delete
 elif [[ $TRAVIS_BRANCH == 'staging'  ]]; then
 aws s3 sync $EXCLUDES _site s3://datalab-staging-usaspending-gov --delete
-elif [[ $TRAVIS_BRANCH == 'dev'      ]]; then
+elif [[ $TRAVIS_BRANCH == 'sandbox'      ]]; then
 aws s3 sync $EXCLUDES _site s3://datalab-dev-usaspending-gov --delete
 fi
 
@@ -30,8 +30,8 @@ export buildstatus=$(( $? | $buildstatus ))
 aws configure set aws_access_key_id $FIR_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $FIR_SECRET_ACCESS_KEY
 
-if [[ $TRAVIS_BRANCH == 'dev'     ]]; then
-aws s3 sync $EXCLUDES _site s3://datalab-dev --delete || true
+if [[ $TRAVIS_BRANCH == 'sandbox'     ]]; then
+aws s3 sync $EXCLUDES _site s3://fir-public-datalab-dev --delete || true
 fi
 
 exit $buildstatus

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,6 +1,13 @@
 jekyll build
+
+# Used so Travis can display the correct build status
+export buildstatus=$?
+
 pip install requests[security] --user
+export buildstatus=$(( $? | $buildstatus ))
+
 pip install awscli --user
+export buildstatus=$(( $? | $buildstatus ))
 
 aws configure set region us-gov-west-1
 aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
@@ -13,14 +20,18 @@ if [[ $TRAVIS_BRANCH == 'master'     ]]; then
 aws s3 sync $EXCLUDES _site s3://datalab-usaspending-gov --delete
 elif [[ $TRAVIS_BRANCH == 'staging'  ]]; then
 aws s3 sync $EXCLUDES _site s3://datalab-staging-usaspending-gov --delete
-elif [[ $TRAVIS_BRANCH == 'sandbox'      ]]; then
+elif [[ $TRAVIS_BRANCH == 'dev'      ]]; then
 aws s3 sync $EXCLUDES _site s3://datalab-dev-usaspending-gov --delete
 fi
+
+export buildstatus=$(( $? | $buildstatus ))
 
 # FIR Copies (uses same aws region)
 aws configure set aws_access_key_id $FIR_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $FIR_SECRET_ACCESS_KEY
 
-if [[ $TRAVIS_BRANCH == 'sandbox'     ]]; then
-aws s3 sync $EXCLUDES _site s3://fir-public-datalab-dev --delete || true
+if [[ $TRAVIS_BRANCH == 'dev'     ]]; then
+aws s3 sync $EXCLUDES _site s3://datalab-dev --delete || true
 fi
+
+exit $buildstatus


### PR DESCRIPTION
We realized yesterday that the final `if` (combined with the `|| true` overrides any nonzero exit codes. This adds a buildstatus variable that gets logical or'ed after the most critical parts of the script (I ignored exports and aws configs, and the final `if || true`, which will always exit with a 0.