### PR TITLE
hiding overflow area on bubble chart when zoomed in

### DIFF
--- a/css/C-a-U.scss
+++ b/css/C-a-U.scss
@@ -742,6 +742,7 @@ $cuRed: #881E3D;
             position: absolute;
             top: 0;
             left: 0;
+			overflow: hidden;
           }
 
           #agency-legend_colorKey {


### PR DESCRIPTION
**High level description:**
C&U - IE Bubble Chart When Zoomed is Covering Next Section on Scroll

**Technical details:**
Changed CSS for IE

**JIRA ticket:**
[DA-4375](https://federal-spending-transparency.atlassian.net/browse/DA-4375)

The following are ALL required for the PR to be merged:

- [ ] Code review (n/a)
- [ ] Design approved by [designer's name] (n/a)
- [x] Verified cross-browser compatibility
- [x] Verified mobile, tablet, and desktop
