### PR TITLE
Sunburst search

### DIFF
--- a/src/components/visualizations/sunburst-vega/sunburst-vega.jsx
+++ b/src/components/visualizations/sunburst-vega/sunburst-vega.jsx
@@ -35,7 +35,7 @@ export default class Sunburst extends React.Component {
     this.handleClick = this.handleClick.bind(this);
     this.filterSunburst = this.filterSunburst.bind(this);
     this.appendColors = this.appendColors.bind(this);
-    this.updateViz = this.updateViz.bind(this);
+    this.updateSunburst = this.updateSunburst.bind(this);
     this.signalListeners = { arcClick: this.handleClick, arcHover: this.handleHover, arcUnhover: this.handleUnhover };
   }
 
@@ -70,20 +70,20 @@ export default class Sunburst extends React.Component {
 
   handleClick(...args) {
     const item = args[1];
-    this.updateViz(item);
+    this.updateSunburst(item);
   }
 
-  updateViz(arc) {
+  updateSunburst(arc) {
     const previousArc = this.state.selectedArc;
     this.setState({ selectedArc: arc });
-    const newData = this.state.selectedArc.id === 1 ? this.state.originalData : { "tree": this.filterSunburst() };
+    const newData = this.state.selectedArc.id === 1 ? this.state.originalData : { "tree": this.filterSunburst(this.state.selectedArc) };
     this.props.getSelectedArc(this.state.selectedArc);
     this.setState({ data: newData, previousArc: previousArc });
   }
 
-  filterSunburst() {
+  filterSunburst(selectedArc) {
     const flare = this.state.originalData;
-    const { agency, name, depth } = this.state.selectedArc;
+    const { agency, name, depth } = selectedArc;
     let recipientSubAgencyIds, recipients, subagencies, subAgencyIds, agencyNames;
 
     if (depth === 2) {

--- a/src/components/visualizations/sunburst-vega/sunburst-vega.jsx
+++ b/src/components/visualizations/sunburst-vega/sunburst-vega.jsx
@@ -25,29 +25,25 @@ export default class Sunburst extends React.Component {
       selectedArc: this.props.default,
       previousArc: this.props.default
     };
-
-    this.handleHover = this.handleHover.bind(this);
-    this.handleUnhover = this.handleUnhover.bind(this);
-    this.handleClick = this.handleClick.bind(this);
-    this.updateData = this.updateData.bind(this);
+    
     this.signalListeners = { arcClick: this.handleClick, arcHover: this.handleHover, arcUnhover: this.handleUnhover };
   }
 
-  handleUnhover() {
+  handleUnhover = () => {
     this.props.updatePanels();
   }
 
-  handleHover(...args) {
+  handleHover = (...args) => {
     const item = args[1];
     this.props.updatePanels(item);
   }
 
-  handleClick(...args) {
+  handleClick = (...args) => {
     const item = args[1];
     this.props.updateSunburst(item);
   }
 
-  updateData(data) {
+  updateData = (data) => {
     this.setState({data: data});
   }
 

--- a/src/components/visualizations/sunburst-vega/sunburst-vega.jsx
+++ b/src/components/visualizations/sunburst-vega/sunburst-vega.jsx
@@ -34,12 +34,12 @@ export default class Sunburst extends React.Component {
   }
 
   handleUnhover() {
-    this.props.getSelectedArc(this.state.selectedArc);
+    this.props.updatePanels();
   }
 
   handleHover(...args) {
     const item = args[1];
-    this.props.getSelectedArc(item);
+    this.props.updatePanels(item);
   }
 
   handleClick(...args) {
@@ -64,7 +64,8 @@ export default class Sunburst extends React.Component {
 }
 
 Sunburst.propTypes = {
-  getSelectedArc: PropTypes.func.isRequired,
+  updatePanels: PropTypes.func.isRequired,
+  updateSunburst: PropTypes.func.isRequired,
   default: PropTypes.object.isRequired,
   data: PropTypes.object.isRequired
 }

--- a/src/components/visualizations/sunburst-vega/sunburst-vega.jsx
+++ b/src/components/visualizations/sunburst-vega/sunburst-vega.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import { Vega } from 'react-vega';
 import sunburstSpec from './utils/sunburst-spec';
-import * as _ from 'lodash';
 
 import './sunburst-vega.scss';
 import PropTypes from "prop-types"
@@ -20,44 +19,19 @@ export default class Sunburst extends React.Component {
         side but hasn't been rewritten yet due to the analyst backlog being long. */
     // console.log(transformData());
 
-    const data = this.appendColors(this.props.data);
-
     this.state = {
-      data: data,
+      data: this.props.data,
       spec: sunburstSpec,
-      originalData: data,
-      selectedArc: { name: 'flare', depth: 0 },
-      previousArc: { name: 'flare', depth: 0 }
+      selectedArc: this.props.default,
+      previousArc: this.props.default
     };
 
     this.handleHover = this.handleHover.bind(this);
     this.handleUnhover = this.handleUnhover.bind(this);
     this.handleClick = this.handleClick.bind(this);
-    this.filterSunburst = this.filterSunburst.bind(this);
-    this.appendColors = this.appendColors.bind(this);
-    this.updateSunburst = this.updateSunburst.bind(this);
+    this.updateData = this.updateData.bind(this);
     this.signalListeners = { arcClick: this.handleClick, arcHover: this.handleHover, arcUnhover: this.handleUnhover };
   }
-
-  appendColors(flare) {
-    let agencies = _.filter(flare.tree, { 'type': 'agency' });
-    let agenciesColors = {};
-    let colors = this.props.colors;
-    agencies = _.map(agencies, 'name');
-    agencies = _.uniqBy(agencies);
-
-    for (let i = 0; i < agencies.length; i++) {
-      agenciesColors[agencies[i]] = colors[i % colors.length];
-    }
-
-    flare.tree[0]['colorHex'] = '#fff';
-
-    for (let i = 1; i < flare.tree.length; i++) {
-      flare.tree[i]['colorHex'] = agenciesColors[flare.tree[i].agency];
-    }
-
-    return flare;
-  };
 
   handleUnhover() {
     this.props.getSelectedArc(this.state.selectedArc);
@@ -70,73 +44,11 @@ export default class Sunburst extends React.Component {
 
   handleClick(...args) {
     const item = args[1];
-    this.updateSunburst(item);
+    this.props.updateSunburst(item);
   }
 
-  updateSunburst(arc) {
-    const previousArc = this.state.selectedArc;
-    this.setState({ selectedArc: arc });
-    const newData = this.state.selectedArc.id === 1 ? this.state.originalData : { "tree": this.filterSunburst(this.state.selectedArc) };
-    this.props.getSelectedArc(this.state.selectedArc);
-    this.setState({ data: newData, previousArc: previousArc });
-  }
-
-  filterSunburst(selectedArc) {
-    const flare = this.state.originalData;
-    const { agency, name, depth } = selectedArc;
-    let recipientSubAgencyIds, recipients, subagencies, subAgencyIds, agencyNames;
-
-    if (depth === 2) {
-      subagencies = _.filter(flare.tree, { 'name': name, 'type': 'subagency' });
-      agencyNames = _.map(subagencies, 'agency');
-      agencyNames = _.uniqBy(agencyNames);
-      subAgencyIds = _.map(subagencies, 'id');
-
-    } else if (depth === 3) {
-      recipients = _.filter(flare.tree, { 'name': name, 'type': 'recipient' });
-      agencyNames = _.map(recipients, 'agency');
-      agencyNames = _.uniqBy(agencyNames);
-      recipientSubAgencyIds = _.map(recipients, 'parent');
-
-    }
-
-    const filtered = flare.tree.filter(function (arc) {
-      if(arc.id === 1) {
-        return true;
-      }
-
-      if(depth === 1) {
-        return arc.agency === agency;
-
-      } else if (depth === 2) {
-        switch (arc.depth) {
-          case 1:
-            return agencyNames.includes(arc.name);
-
-          case 2:
-            return arc.name === name;
-
-          case 3:
-            return subAgencyIds.includes(arc.parent);
-
-        }
-
-      } else if (depth === 3) {
-        switch (arc.depth) {
-          case 1:
-            return agencyNames.includes(arc.name);
-
-          case 2:
-            return recipientSubAgencyIds.includes(arc.id);
-
-          case 3:
-            return arc.name === name;
-
-        }
-      }
-    });
-
-    return filtered;
+  updateData(data) {
+    this.setState({data: data});
   }
 
   render() {
@@ -153,6 +65,6 @@ export default class Sunburst extends React.Component {
 
 Sunburst.propTypes = {
   getSelectedArc: PropTypes.func.isRequired,
-  colors: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  default: PropTypes.object.isRequired,
   data: PropTypes.object.isRequired
 }

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -82,10 +82,7 @@ const SunburstVegaContainer = () => {
 
   const searchSelect = (id) => {
     const selectedArc = findArcById(sunData, id);
-    setSelectedArc(selectedArc);
-    // if (sunburstRef && sunburstRef.current) {
-    //   sunburstRef.current.updateSunburst(selectedArc);
-    // }
+    updateSunburst(selectedArc);
   }
 
   function updateSunburst(selectedArc) {
@@ -93,11 +90,11 @@ const SunburstVegaContainer = () => {
     const newData = selectedArc.id === 1 ? sunData : { "tree": filterSunburst(sunData, selectedArc) };
 
     if (sunburstRef && sunburstRef.current) { sunburstRef.current.updateData(newData); }
-    
+
     setSelectedArc(selectedArc);
     setPreviousArc(previousArc);
     setData(newData);
-    // Update the sections here - ie. breadcrumbs, details,
+    updatePanels(selectedArc);
   }
 
   function getTop5(items, type) {
@@ -158,6 +155,7 @@ const SunburstVegaContainer = () => {
     // if depth is 0, the item flare will be selected
     const selectedArc = findArcByName(sunData, d);
     setSelectedArc(selectedArc);
+    updateSunburst(selectedArc);
   }
 
   const breadcrumbRef = React.createRef();
@@ -213,12 +211,12 @@ const SunburstVegaContainer = () => {
 
   // Upon arc selection, sunburst sends the arc info to the container
   // Use arc to the arc color, selected arc, update breadcrumbs and get details
-  function getSelectedArc(selectedArc) {
-    const tempPreviousArc = arc;
-    updateBreadcrumbs(selectedArc);
-    getDetails(selectedArc);
-    setPreviousArc(tempPreviousArc);
-    setSelectedArc(selectedArc);
+  function updatePanels(tempArc) {
+    if(tempArc !== arc) {
+      const item = tempArc ? tempArc : arc;
+      updateBreadcrumbs(item);
+      getDetails(item);
+    }
   }
 
   return <>
@@ -239,7 +237,7 @@ const SunburstVegaContainer = () => {
           <BreadCrumbs className={`${styles.header} ${styles.breadcrumbsContainer}`} items={breadcrumbs} onSelect={selectBreadcrumb} ref={breadcrumbRef} />
           <Sunburst
             data={updatedSunData}
-            getSelectedArc={getSelectedArc}
+            updatePanels={updatePanels}
             updateSunburst={updateSunburst}
             default={defaultSelection}
             ref={sunburstRef} />
@@ -258,7 +256,7 @@ const SunburstVegaContainer = () => {
       <BreadCrumbs className={`${styles.header} ${styles.breadcrumbsContainer}`} items={breadcrumbs} onSelect={selectBreadcrumb} ref={breadcrumbRef} />
       <Sunburst
         data={updatedSunData}
-        getSelectedArc={getSelectedArc}
+        updatePanels={updatePanels}
         updateSunburst={updateSunburst}
         default={defaultSelection}
         ref={sunburstRef} />

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -25,7 +25,7 @@ const SunburstVegaContainer = () => {
   const [arc, setSelectedArc] = useState(null);
   const [previousArc, setPreviousArc] = useState(null);
   const [breadcrumbs, setBreadcrumbs] = useState(null);
-  const [details, setDetails] = useState(null);
+  const [details, setDetails] = useState({});
   const [sunData, setOriginalData] = useState(flareData);
   const [updatedSunData, setData] = useState(sunData);
 
@@ -69,7 +69,7 @@ const SunburstVegaContainer = () => {
 
   const searchSelect = (id) => {
     const selectedArc = findArcById(sunData, id);
-    updateSunburst(selectedArc);
+    getSearchResults(selectedArc);
   }
 
   function updateSunburst(selectedArc) {
@@ -81,7 +81,6 @@ const SunburstVegaContainer = () => {
     setSelectedArc(selectedArc);
     setPreviousArc(previousArc);
     setData(newData);
-    updatePanels(selectedArc);
   }
 
   function getTop5(items, type) {
@@ -142,7 +141,7 @@ const SunburstVegaContainer = () => {
     // if depth is 0, the item flare will be selected
     const selectedArc = findArcByName(sunData, d);
     setSelectedArc(selectedArc);
-    updateSunburst(selectedArc);
+    updateAll(selectedArc);
   }
 
   const breadcrumbRef = React.createRef();
@@ -167,28 +166,41 @@ const SunburstVegaContainer = () => {
       name: null
     };
 
+
     // get the top contribution for the selection
     switch (depth) {
       case 0:
         details.total = awardsData.reduce((a, b) => a + (b.obligation || 0), 0);
+        break;
       case 1:
-        details.label= `${pretext} ${selectedArc.name}`;
-        details.total = awardsData.filter(node => node.agency === selectedArc.name).reduce((a, b) => a + (b.obligation || 0), 0);
+        details.label = `${pretext} ${selectedArc.name}`;
+        const agencyAwardsData = awardsData.filter(node => node.agency === selectedArc.name);
+        details.total = agencyAwardsData.reduce((a, b) => a + (b.obligation || 0), 0);
+        details.top5 = getTop5(agencyAwardsData, 'agency');
+        // find all instances of the agency
+        break;
       case 2:
-        details.label= `${pretext} ${selectedArc.name}`;
-        details.total = awardsData.filter(node => node.subagency === selectedArc.name).reduce((a, b) => a + (b.obligation || 0), 0);
+        details.label = `${pretext} ${selectedArc.name}`;
+        const subagencyAwardsData = awardsData.filter(node => node.subagency === selectedArc.name);
+        details.total = subagencyAwardsData.reduce((a, b) => a + (b.obligation || 0), 0);
+        details.top5 = getTop5(subagencyAwardsData, 'agency');
+
+        // find all instances of the agency
+
+        break;
 
       case 3:
-        details.label= `${pretext} ${selectedArc.name}`;
-        details.total = awardsData.filter(node => node.recipient === selectedArc.name).reduce((a, b) => a + (b.obligation || 0), 0);
+        details.label = `${pretext} ${selectedArc.name}`;
+        const recipientAwardsData = awardsData.filter(node => node.recipient === selectedArc.name);
+        details.total = recipientAwardsData.reduce((a, b) => a + (b.obligation || 0), 0);
+        details.top5 = getTop5(recipientAwardsData, 'agency');
+        break;
+    }
 
+    updateSunburst(selectedArc);
+    updateBreadcrumbs(selectedArc);
 
-        details.label = 'Agencies';
-    details.total = awardsData.reduce((a, b) => a + (b.obligation || 0), 0);
-    details.top5 = getTop5(awardsData, 'agency');
-    details.name = 'Contract Spending In Fiscal Year 2019';
-    const agencies = sunData.filter(node => node.agency === selectedArc.agency);
-    details.total = sunData.filter(node => node.agency === selectedArc.agency).reduce((a, b) => a + (b.obligation || 0), 0);
+    setDetails(details);
 
   }
 
@@ -238,9 +250,16 @@ const SunburstVegaContainer = () => {
   function updatePanels(tempArc) {
     if(tempArc !== arc) {
       const item = tempArc ? tempArc : arc;
-      updateBreadcrumbs(item);
       getDetails(item);
+      updateBreadcrumbs(item);
     }
+  }
+
+
+  function updateAll(selectedArc) {
+    updateSunburst(selectedArc);
+    updateBreadcrumbs(selectedArc);
+    updatePanels(selectedArc);
   }
 
   return <>

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -84,7 +84,7 @@ const SunburstVegaContainer = () => {
     if (sunburstRef && sunburstRef.current) {
       sunburstRef.current.updateSunburst(selectedArc);
     }
-    setSelectedArc(selectedArc);
+    // setSelectedArc(selectedArc);
   }
 
   useEffect(() => {

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -250,16 +250,16 @@ const SunburstVegaContainer = () => {
   function updatePanels(tempArc) {
     if(tempArc !== arc) {
       const item = tempArc ? tempArc : arc;
-      getDetails(item);
       updateBreadcrumbs(item);
+      getDetails(item);
     }
   }
 
 
   function updateAll(selectedArc) {
-    updateSunburst(selectedArc);
     updateBreadcrumbs(selectedArc);
     updatePanels(selectedArc);
+    updateSunburst(selectedArc);
   }
 
   return <>
@@ -281,7 +281,7 @@ const SunburstVegaContainer = () => {
           <Sunburst
             data={updatedSunData}
             updatePanels={updatePanels}
-            updateSunburst={updateSunburst}
+            updateSunburst={updateAll}
             default={defaultSelection}
             ref={sunburstRef} />
           <div className={styles.sunburstMessage}>The visualization contains data on primary awards to recipients. Sub-awards are not included.</div>
@@ -300,7 +300,7 @@ const SunburstVegaContainer = () => {
       <Sunburst
         data={updatedSunData}
         updatePanels={updatePanels}
-        updateSunburst={updateSunburst}
+        updateSunburst={updateAll}
         default={defaultSelection}
         ref={sunburstRef} />
       <div className={styles.sunburstMessage}>The visualization contains data on primary awards to recipients. Sub-awards are not included.</div>

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -30,8 +30,10 @@ const SunburstVegaContainer = () => {
   const [updatedSunData, setData] = useState(sunData);
 
   useEffect(() => {
+    const details = getDetails();
     setOriginalData(appendColors(flareData));
-    getDetails();
+    setDetails(details);
+
   }, []);
 
   // create arrays of unique agencies, subagencies and recipients with ID for search list
@@ -240,7 +242,7 @@ const SunburstVegaContainer = () => {
   // Use arc to the arc color, selected arc, update breadcrumbs and get details
   function updatePanels(tempArc) {
     if(tempArc !== arc) {
-      const item = tempArc ? tempArc : arc;
+      const item = tempArc ? tempArc : defaultSelection;
       const trail = updateBreadcrumbs(item);
       const details = getDetails(item);
 
@@ -288,7 +290,7 @@ const SunburstVegaContainer = () => {
             onSelect={searchSelect}
           />
           <div className={styles.sunburstDetails}>
-            {/*<SunburstDetails details={sunburstDetails} />*/}
+            <SunburstDetails details={sunburstDetails} />
           </div>
         </Grid>
         <Grid item md={6}>
@@ -321,7 +323,7 @@ const SunburstVegaContainer = () => {
       <div className={styles.sunburstMessage}>The visualization contains data on primary awards to recipients. Sub-awards are not included.</div>
       <Downloads className={styles.downloadContainer}
                  href={'/unstructured-data/contract-explorer/awards_contracts_FY18_v2.csv'} />
-      {/*<SunburstDetails details={sunburstDetails} />*/}
+      <SunburstDetails details={sunburstDetails} />
     </Hidden>
   </>;
 }

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -155,6 +155,43 @@ const SunburstVegaContainer = () => {
     setBreadcrumbs(trail);
   }
 
+  // list the agencies for the selected
+  function getSearchResults(selectedArc) {
+    const depth = selectedArc && selectedArc.depth ? selectedArc.depth : 0;
+    const pretext = 'Total Contracts Related To';
+
+    const details = {
+      label: null,
+      total: null,
+      top5: [],
+      name: null
+    };
+
+    // get the top contribution for the selection
+    switch (depth) {
+      case 0:
+        details.total = awardsData.reduce((a, b) => a + (b.obligation || 0), 0);
+      case 1:
+        details.label= `${pretext} ${selectedArc.name}`;
+        details.total = awardsData.filter(node => node.agency === selectedArc.name).reduce((a, b) => a + (b.obligation || 0), 0);
+      case 2:
+        details.label= `${pretext} ${selectedArc.name}`;
+        details.total = awardsData.filter(node => node.subagency === selectedArc.name).reduce((a, b) => a + (b.obligation || 0), 0);
+
+      case 3:
+        details.label= `${pretext} ${selectedArc.name}`;
+        details.total = awardsData.filter(node => node.recipient === selectedArc.name).reduce((a, b) => a + (b.obligation || 0), 0);
+
+
+        details.label = 'Agencies';
+    details.total = awardsData.reduce((a, b) => a + (b.obligation || 0), 0);
+    details.top5 = getTop5(awardsData, 'agency');
+    details.name = 'Contract Spending In Fiscal Year 2019';
+    const agencies = sunData.filter(node => node.agency === selectedArc.agency);
+    details.total = sunData.filter(node => node.agency === selectedArc.agency).reduce((a, b) => a + (b.obligation || 0), 0);
+
+  }
+
   function getDetails (selectedArc) {
     const depth = selectedArc && selectedArc.depth ? selectedArc.depth : 0;
 

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -22,7 +22,7 @@ const SunburstVegaContainer = () => {
     depth: 0
   }
 
-  const [arc, setSelectedArc] = useState(null);
+  const [arc, setSelectedArc] = useState(defaultSelection);
   const [previousArc, setPreviousArc] = useState(null);
   const [breadcrumbs, setBreadcrumbs] = useState(null);
   const [sunburstDetails, setDetails] = useState({});

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -16,8 +16,6 @@ import findArcByName from './utils/find-by-name';
 import filterSunburst from './utils/filter';
 
 const SunburstVegaContainer = () => {
-  const colors = ['#7A2149', '#61344A', '#4E4861', '#3F566E', '#3C596A', '#2F6567', '#38705F', '#517852', '#88923D',
-    '#AE933D', '#D39248', '#EA8052'];
 
   const detailDefaults = {
     label: null,
@@ -39,7 +37,7 @@ const SunburstVegaContainer = () => {
   const [updatedSunData, setData] = useState(sunData);
 
   useEffect(() => {
-    setOriginalData(appendColors(flareData, colors));
+    setOriginalData(appendColors(flareData));
     getDetails();
   }, []);
 
@@ -48,7 +46,7 @@ const SunburstVegaContainer = () => {
   const subagencies = [];
   const recipients = [];
 
-  awardsData.map((e, i) => {
+  awardsData.map((e) => {
 
     if (agencies.findIndex(a => a.display === e.agency) === -1) {
       agencies.push({
@@ -73,10 +71,6 @@ const SunburstVegaContainer = () => {
   });
 
   const searchList = agencies.concat(subagencies).concat(recipients);
-
-  // try to force redraw of sunburst (or entire container); NOT WORKING
-  // const [, updateState] = React.useState();
-  // const forceUpdate = React.useCallback(() => updateState({ 'thing': 'one' }), ['thing', 'two']);
 
   const sunburstRef = React.createRef();
 
@@ -109,6 +103,7 @@ const SunburstVegaContainer = () => {
         obligation: items.filter(node => node[type] === unique[i]).reduce((a, b) => a + (b.obligation || 0), 0)
       });
     }
+
     return summedItems.sort((a, b) => (a.obligation < b.obligation) ? 1 : -1).slice(0, 5);
   }
 
@@ -117,6 +112,7 @@ const SunburstVegaContainer = () => {
 
     const breadcrumbs = [];
     const agency = sunData.tree.find(node => node.name === selectedArc.agency);
+    const trail = [defaultSelection];
 
     switch(selectedArc.depth) {
       case 0:
@@ -136,8 +132,6 @@ const SunburstVegaContainer = () => {
         breadcrumbs.push(selectedArc)
         break;
     }
-
-    const trail = [defaultSelection];
 
     breadcrumbs.forEach((item) => {
       trail.push({

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -25,7 +25,7 @@ const SunburstVegaContainer = () => {
   const [arc, setSelectedArc] = useState(null);
   const [previousArc, setPreviousArc] = useState(null);
   const [breadcrumbs, setBreadcrumbs] = useState(null);
-  const [details, setDetails] = useState({});
+  const [sunburstDetails, setDetails] = useState({});
   const [sunData, setOriginalData] = useState(flareData);
   const [updatedSunData, setData] = useState(sunData);
 
@@ -69,18 +69,14 @@ const SunburstVegaContainer = () => {
 
   const searchSelect = (id) => {
     const selectedArc = findArcById(sunData, id);
-    getSearchResults(selectedArc);
+    const details = getSearchResults(selectedArc);
+    updateAfterSearch(selectedArc, details)
   }
 
   function updateSunburst(selectedArc) {
-    const previousArc = arc;
     const newData = selectedArc.id === 1 ? sunData : { "tree": filterSunburst(sunData, selectedArc) };
-
     if (sunburstRef && sunburstRef.current) { sunburstRef.current.updateData(newData); }
-
-    setSelectedArc(selectedArc);
-    setPreviousArc(previousArc);
-    setData(newData);
+    return newData;
   }
 
   function getTop5(items, type) {
@@ -140,7 +136,6 @@ const SunburstVegaContainer = () => {
   function selectBreadcrumb (d) {
     // if depth is 0, the item flare will be selected
     const selectedArc = findArcByName(sunData, d);
-    setSelectedArc(selectedArc);
     updateAll(selectedArc);
   }
 
@@ -151,7 +146,7 @@ const SunburstVegaContainer = () => {
     if (breadcrumbRef && breadcrumbRef.current) {
       breadcrumbRef.current.updateBreadcrumbs(selectedArc.colorHex, trail);
     }
-    setBreadcrumbs(trail);
+    return trail;
   }
 
   // list the agencies for the selected
@@ -197,10 +192,7 @@ const SunburstVegaContainer = () => {
         break;
     }
 
-    updateSunburst(selectedArc);
-    updateBreadcrumbs(selectedArc);
-
-    setDetails(details);
+    return details;
 
   }
 
@@ -241,8 +233,7 @@ const SunburstVegaContainer = () => {
         break;
     }
 
-    setDetails(details);
-
+    return details;
   }
 
   // Upon arc selection, sunburst sends the arc info to the container
@@ -250,16 +241,40 @@ const SunburstVegaContainer = () => {
   function updatePanels(tempArc) {
     if(tempArc !== arc) {
       const item = tempArc ? tempArc : arc;
-      updateBreadcrumbs(item);
-      getDetails(item);
+      const trail = updateBreadcrumbs(item);
+      const details = getDetails(item);
+
+      // set state
+      setBreadcrumbs(trail);
+      setDetails(details);
     }
   }
 
+  function updateAfterSearch(selectedArc, details) {
+    const previousArc = arc;
+    const newData = updateSunburst(selectedArc);
+    const trail = updateBreadcrumbs(selectedArc);
+
+    // set state
+    setBreadcrumbs(trail);
+    setDetails(details);
+    setSelectedArc(selectedArc);
+    setPreviousArc(previousArc);
+    setData(newData);
+  }
 
   function updateAll(selectedArc) {
-    updateBreadcrumbs(selectedArc);
-    updatePanels(selectedArc);
-    updateSunburst(selectedArc);
+    const previousArc = arc;
+    const trail = updateBreadcrumbs(selectedArc);
+    const details = getDetails(selectedArc);
+    const newData = updateSunburst(selectedArc);
+
+    // set state
+    setBreadcrumbs(trail);
+    setDetails(details);
+    setSelectedArc(selectedArc);
+    setPreviousArc(previousArc);
+    setData(newData);
   }
 
   return <>
@@ -273,7 +288,7 @@ const SunburstVegaContainer = () => {
             onSelect={searchSelect}
           />
           <div className={styles.sunburstDetails}>
-            <SunburstDetails details={details} />
+            {/*<SunburstDetails details={sunburstDetails} />*/}
           </div>
         </Grid>
         <Grid item md={6}>
@@ -306,7 +321,7 @@ const SunburstVegaContainer = () => {
       <div className={styles.sunburstMessage}>The visualization contains data on primary awards to recipients. Sub-awards are not included.</div>
       <Downloads className={styles.downloadContainer}
                  href={'/unstructured-data/contract-explorer/awards_contracts_FY18_v2.csv'} />
-      <SunburstDetails details={details} />
+      {/*<SunburstDetails details={sunburstDetails} />*/}
     </Hidden>
   </>;
 }

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -17,13 +17,6 @@ import filterSunburst from './utils/filter';
 
 const SunburstVegaContainer = () => {
 
-  const detailDefaults = {
-    label: null,
-    total: null,
-    top5: [],
-    name: null
-  }
-
   const defaultSelection = {
     name: 'flare',
     depth: 0
@@ -32,7 +25,7 @@ const SunburstVegaContainer = () => {
   const [arc, setSelectedArc] = useState(null);
   const [previousArc, setPreviousArc] = useState(null);
   const [breadcrumbs, setBreadcrumbs] = useState(null);
-  const [details, setDetails] = useState(detailDefaults);
+  const [details, setDetails] = useState(null);
   const [sunData, setOriginalData] = useState(flareData);
   const [updatedSunData, setData] = useState(sunData);
 

--- a/src/containers/contract-explorer/contract-explorer-container.jsx
+++ b/src/containers/contract-explorer/contract-explorer-container.jsx
@@ -242,7 +242,7 @@ const SunburstVegaContainer = () => {
   // Use arc to the arc color, selected arc, update breadcrumbs and get details
   function updatePanels(tempArc) {
     if(tempArc !== arc) {
-      const item = tempArc ? tempArc : defaultSelection;
+      const item = tempArc ? tempArc : arc;
       const trail = updateBreadcrumbs(item);
       const details = getDetails(item);
 

--- a/src/containers/contract-explorer/utils/colors.js
+++ b/src/containers/contract-explorer/utils/colors.js
@@ -1,23 +1,24 @@
-import * as _ from "lodash"
-
 export default function appendColors(sunData) {
   const colors = ['#7A2149', '#61344A', '#4E4861', '#3F566E', '#3C596A', '#2F6567', '#38705F', '#517852', '#88923D',
     '#AE933D', '#D39248', '#EA8052'];
-  let agencies = _.filter(sunData.tree, { 'type': 'agency' });
+  let agencies = sunData.tree.filter(node => node.type === 'agency');
   const agenciesColors = {};
 
-  agencies = _.map(agencies, 'name');
-  agencies = _.uniqBy(agencies);
+  agencies = agencies.map(x => x.name);
+  agencies = [...new Set([agencies])];
+  agencies = agencies.length > 0 ? agencies[0] : null;
 
-  for (let i = 0; i < agencies.length; i++) {
-    agenciesColors[agencies[i]] = colors[i % colors.length];
-  }
+  agencies.forEach(function(item, index) {
+    agenciesColors[item] = colors[index % colors.length]
+  });
 
-  sunData.tree[0]['colorHex'] = '#fff';
-
-  for (let i = 1; i < sunData.tree.length; i++) {
-    sunData.tree[i]['colorHex'] = agenciesColors[sunData.tree[i].agency];
-  }
+  sunData.tree.forEach(function(item, index) {
+    if(index === 0) {
+      sunData.tree[index]['colorHex'] = '#fff';
+    } else {
+      sunData.tree[index]['colorHex'] = agenciesColors[item.agency];
+    }
+  });
 
   return sunData;
 };

--- a/src/containers/contract-explorer/utils/colors.js
+++ b/src/containers/contract-explorer/utils/colors.js
@@ -1,6 +1,8 @@
 import * as _ from "lodash"
 
-export default function appendColors(sunData, colors) {
+export default function appendColors(sunData) {
+  const colors = ['#7A2149', '#61344A', '#4E4861', '#3F566E', '#3C596A', '#2F6567', '#38705F', '#517852', '#88923D',
+    '#AE933D', '#D39248', '#EA8052'];
   let agencies = _.filter(sunData.tree, { 'type': 'agency' });
   const agenciesColors = {};
 

--- a/src/containers/contract-explorer/utils/colors.js
+++ b/src/containers/contract-explorer/utils/colors.js
@@ -1,0 +1,21 @@
+import * as _ from "lodash"
+
+export default function appendColors(sunData, colors) {
+  let agencies = _.filter(sunData.tree, { 'type': 'agency' });
+  const agenciesColors = {};
+
+  agencies = _.map(agencies, 'name');
+  agencies = _.uniqBy(agencies);
+
+  for (let i = 0; i < agencies.length; i++) {
+    agenciesColors[agencies[i]] = colors[i % colors.length];
+  }
+
+  sunData.tree[0]['colorHex'] = '#fff';
+
+  for (let i = 1; i < sunData.tree.length; i++) {
+    sunData.tree[i]['colorHex'] = agenciesColors[sunData.tree[i].agency];
+  }
+
+  return sunData;
+};

--- a/src/containers/contract-explorer/utils/filter.js
+++ b/src/containers/contract-explorer/utils/filter.js
@@ -1,22 +1,21 @@
-import * as _ from "lodash"
-
 export default function filterSunburst(sunData, selectedArc) {
   const flare = sunData;
   const { agency, name, depth } = selectedArc;
   let recipientSubAgencyIds, recipients, subagencies, subAgencyIds, agencyNames;
 
   if (depth === 2) {
-    subagencies = _.filter(flare.tree, { 'name': name, 'type': 'subagency' });
-    agencyNames = _.map(subagencies, 'agency');
-    agencyNames = _.uniqBy(agencyNames);
-    subAgencyIds = _.map(subagencies, 'id');
+    subagencies = flare.tree.filter(node => node.name === name && node.type === 'subagency');
+    agencyNames = subagencies.map(x => x.agency);
+    agencyNames = [...new Set([agencyNames])];
+    agencyNames = agencyNames.length > 0 ? agencyNames[0] : null;
+    subAgencyIds = subagencies.map(x => x.id);
 
   } else if (depth === 3) {
-    recipients = _.filter(flare.tree, { 'name': name, 'type': 'recipient' });
-    agencyNames = _.map(recipients, 'agency');
-    agencyNames = _.uniqBy(agencyNames);
-    recipientSubAgencyIds = _.map(recipients, 'parent');
-
+    recipients = flare.tree.filter(node => node.name === name && node.type === 'recipient');
+    agencyNames = recipients.map(x => x.agency);
+    agencyNames = [...new Set([agencyNames])];
+    agencyNames = agencyNames.length > 0 ? agencyNames[0] : null;
+    recipientSubAgencyIds = recipients.map(x => x.parent);
   }
 
   const filtered = flare.tree.filter(function (arc) {

--- a/src/containers/contract-explorer/utils/filter.js
+++ b/src/containers/contract-explorer/utils/filter.js
@@ -1,0 +1,60 @@
+import * as _ from "lodash"
+
+export default function filterSunburst(sunData, selectedArc) {
+  const flare = sunData;
+  const { agency, name, depth } = selectedArc;
+  let recipientSubAgencyIds, recipients, subagencies, subAgencyIds, agencyNames;
+
+  if (depth === 2) {
+    subagencies = _.filter(flare.tree, { 'name': name, 'type': 'subagency' });
+    agencyNames = _.map(subagencies, 'agency');
+    agencyNames = _.uniqBy(agencyNames);
+    subAgencyIds = _.map(subagencies, 'id');
+
+  } else if (depth === 3) {
+    recipients = _.filter(flare.tree, { 'name': name, 'type': 'recipient' });
+    agencyNames = _.map(recipients, 'agency');
+    agencyNames = _.uniqBy(agencyNames);
+    recipientSubAgencyIds = _.map(recipients, 'parent');
+
+  }
+
+  const filtered = flare.tree.filter(function (arc) {
+    if(arc.id === 1) {
+      return true;
+    }
+
+    if(depth === 1) {
+      return arc.agency === agency;
+
+    } else if (depth === 2) {
+      switch (arc.depth) {
+        case 1:
+          return agencyNames.includes(arc.name);
+
+        case 2:
+          return arc.name === name;
+
+        case 3:
+          return subAgencyIds.includes(arc.parent);
+
+      }
+
+    } else if (depth === 3) {
+      switch (arc.depth) {
+        case 1:
+          return agencyNames.includes(arc.name);
+
+        case 2:
+          return recipientSubAgencyIds.includes(arc.id);
+
+        case 3:
+          return arc.name === name;
+
+      }
+    }
+  });
+
+  return filtered;
+
+}

--- a/src/containers/contract-explorer/utils/find-by-id.js
+++ b/src/containers/contract-explorer/utils/find-by-id.js
@@ -1,0 +1,19 @@
+export default function findArcById(sunData, id) {
+  const depth = id.substring(0, 1);
+  const name = id.substring(1);
+  let selectedArc;
+
+  switch(depth) {
+    case 'a':
+      selectedArc = sunData.tree.find(node => node.name === name && node.depth === 1);
+      break;
+    case 's':
+      selectedArc = sunData.tree.find(node => node.name === name && node.depth === 2);
+      break;
+    case 'r':
+      selectedArc = sunData.tree.find(node => node.name === name && node.depth === 3);
+      break;
+  }
+
+  return selectedArc;
+}

--- a/src/containers/contract-explorer/utils/find-by-name.js
+++ b/src/containers/contract-explorer/utils/find-by-name.js
@@ -1,0 +1,5 @@
+export default function findArcByName(sunData, d) {
+  // if depth is 0, the item flare will be selected
+  return sunData.tree.find(node => node.depth === d.depth && node.name === d.name);
+}
+

--- a/src/pages/contract-explorer/index.jsx
+++ b/src/pages/contract-explorer/index.jsx
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
 
-import Accordion from '../../components/accordion/accordion';
-import Reset from '../../components/reset/reset';
-import SEO from '../../components/seo';
-import Share from '../../components/share/share';
-import ToolLayout from '../../components/layouts/tool/tool';
-import ControlBar from "../../components/control-bar/control-bar";
+import Accordion from 'src/components/accordion/accordion';
+import SEO from 'src/components/seo';
+import Share from 'src/components/share/share';
+import ToolLayout from 'src/components/layouts/tool/tool';
+import ControlBar from "src/components/control-bar/control-bar";
 
 import loadable from '@loadable/component';
 import CircularProgress from "@material-ui/core/CircularProgress/CircularProgress";


### PR DESCRIPTION
JIRA Ticket - https://federal-spending-transparency.atlassian.net/browse/DA-5540

* The visualization should update after selecting an item from the search (on par with prod)
* Updated the left details panels to list the top five agencies after selecting an item from search (on par with prod)
* Left the breadcrumbs available after selecting a search item to orient the user.  This is the only way for the user to determine if he has selected an agency, subagency, or contractor from the search.
