### PR TITLE
5469 fix employees in ie

### DIFF
--- a/src/components/section-elements/story-section/story-section.jsx
+++ b/src/components/section-elements/story-section/story-section.jsx
@@ -8,7 +8,7 @@ function StorySection(props) {
     <>
       <Grid container justify="center" className={storySectionStyles.storySection}>
         <Grid item xs={12} xl={10}>
-            <section id={`section-${props.header.section}`}>
+          <section id={`section-${props.header.section}`}>
             <StorySectionHeading
               number={props.header.number}
               title={props.header.subtext}
@@ -19,11 +19,7 @@ function StorySection(props) {
             <Grid container justify="center">
               <Grid item xs={12}>
                 <div className={storySectionStyles.alignLeft}>
-                  <div className="row">
-                    <div className="col-xs-12">
-                      {props.children}
-                    </div>
-                  </div>
+                  {props.children}
                 </div>
               </Grid>
             </Grid>

--- a/src/components/visualizations/federal-employees/bar-chart/bar-chart.jsx
+++ b/src/components/visualizations/federal-employees/bar-chart/bar-chart.jsx
@@ -166,7 +166,7 @@ function BarChart(props) {
           />
         </div>
       </div>
-      <div className={`fed-emp-bar-chart ${barChartStyles.visContainer}`}>
+      <div className={`fed-emp-bar-chart ${barChartStyles.barContainer}`}>
         <svg width='900' height='500' viewBox='0 0 900 500' id='barChartSvg' className={barChartStyles.visBarChart} />
         {legend()}
       </div>

--- a/src/components/visualizations/federal-employees/bar-chart/bar-chart.module.scss
+++ b/src/components/visualizations/federal-employees/bar-chart/bar-chart.module.scss
@@ -1,4 +1,6 @@
-.visContainer {
+@import '../../../../styles/variables.scss';
+
+.barContainer {
   display: flex;
   justify-content: center;
   padding: 2vw;
@@ -10,7 +12,7 @@
   }
 }
 
-.visContainer > svg > g > rect:hover {
+.barContainer > svg > g > rect:hover {
   fill: #d334ba;
 }
 
@@ -68,5 +70,29 @@
       flex-direction: column !important;
       padding-left: 0;
     }
+  }
+}
+
+@media (min-width: $desktop) {
+  .barContainer {
+    height: 550px;
+  }
+}
+
+@media (min-width: $tablet) and (max-width: $desktop - 1) {
+  .barContainer {
+    height: 420px;
+  }
+}
+
+@media (min-width: $phone) and (max-width: $tablet - 1) {
+  .barContainer {
+    height: 350px;
+  }
+}
+
+@media (max-width: $phone) {
+  .barContainer {
+    height: 375px;
   }
 }

--- a/src/components/visualizations/federal-employees/mapviz/mapviz.jsx
+++ b/src/components/visualizations/federal-employees/mapviz/mapviz.jsx
@@ -146,7 +146,7 @@ export default function Mapviz(props) {
     }
   }
 
-  function reset(){
+  function reset() {
     setSelectedAgencies([]);
     setSelectedOccupations([]);
   }
@@ -170,15 +170,15 @@ export default function Mapviz(props) {
         function filterOccupationsList() {
           if (selectedAgencies.length) {
             let currentOccupations = [];
-              selectedAgencies.forEach(agency => {
-                if(agencyOccupationIds[agency.id]){
-                  agencyOccupationIds[agency.id].forEach(occupationId => {
-                    if (!currentOccupations.includes(occupationId)) {
-                      currentOccupations.push(occupationId);
-                    }
-                  })
-                }
-              })
+            selectedAgencies.forEach(agency => {
+              if (agencyOccupationIds[agency.id]) {
+                agencyOccupationIds[agency.id].forEach(occupationId => {
+                  if (!currentOccupations.includes(occupationId)) {
+                    currentOccupations.push(occupationId);
+                  }
+                })
+              }
+            })
 
             occupationOptionList = currentOccupations.map((occupationId) => {
               return Object.values(occupationCategories).find((occupation) => {
@@ -231,34 +231,38 @@ export default function Mapviz(props) {
   return (
     <>
       <ControlBar>
-        <Reset _resetClick={reset}/>
-        <Share location={props.location}/>
+        <Reset _resetClick={reset} />
+        <Share location={props.location} />
       </ControlBar>
       <div id="tooltip" className="tooltip-module" />
       <div id="mapVizToolbar" className={`row ${barChartStyles.toolbar}`}>
         <div className={`filter-tools ${barChartStyles.formItem}`}>
-          <Multiselector key={'mapVizAgencies'}
-                         optionList={agencyOptionList}
-                         valueKey={'id'}
-                         labelKey={'name'}
-                         selectedVal={selectedAgencies}
-                         placeholder={'Agencies'}
-                         id={'mapVizAgencies'}
-                         changeHandler={setSelectedAgencies} />
+          <Multiselector
+            key={'mapVizAgencies'}
+            optionList={agencyOptionList}
+            valueKey={'id'}
+            labelKey={'name'}
+            selectedVal={selectedAgencies}
+            placeholder={'Agencies'}
+            id={'mapVizAgencies'}
+            changeHandler={setSelectedAgencies}
+          />
         </div>
         <div className={`filter-tools ${barChartStyles.formItem}`}>
-          <Multiselector key={'mapVizOccupations'}
-                         optionList={occupationOptionList}
-                         valueKey={'id'}
-                         labelKey={'name'}
-                         selectedVal={selectedOccupations}
-                         placeholder={'Occupations'}
-                         id={occupationName}
-                         changeHandler={setSelectedOccupations} />
+          <Multiselector
+            key={'mapVizOccupations'}
+            optionList={occupationOptionList}
+            valueKey={'id'}
+            labelKey={'name'}
+            selectedVal={selectedOccupations}
+            placeholder={'Occupations'}
+            id={occupationName}
+            changeHandler={setSelectedOccupations}
+          />
         </div>
       </div>
-      <div className="visContainer">
-        <svg width="947" height="700" viewBox="0 0 1200 700" id="mapSvg" className={mapStyles.mapSvg}/>
+      <div className={mapStyles.mapContainer}>
+        <svg width="947" height="700" viewBox="0 0 1200 700" id="mapSvg" className={mapStyles.mapSvg} />
       </div>
     </>
   );

--- a/src/components/visualizations/federal-employees/mapviz/mapviz.module.scss
+++ b/src/components/visualizations/federal-employees/mapviz/mapviz.module.scss
@@ -1,3 +1,5 @@
+@import '../../../../styles/variables.scss';
+
 .map-svg {
   width: 100%;
   height: auto;
@@ -7,4 +9,28 @@
   fill: none;
   stroke: #a9a9a9;
   stroke-width: 1;
+}
+
+@media (min-width: $desktop) {
+  .mapContainer {
+    height: 650px;
+  }
+}
+
+@media (min-width: $tablet) and (max-width: $desktop - 1) {
+  .mapContainer {
+    height: 500px;
+  }
+}
+
+@media (min-width: $phone) and (max-width: $tablet - 1) {
+  .mapContainer {
+    height: 400px;
+  }
+}
+
+@media (max-width: $phone) {
+  .mapContainer {
+    height: 375px;
+  }
 }

--- a/src/components/visualizations/federal-employees/treemap/treemap.jsx
+++ b/src/components/visualizations/federal-employees/treemap/treemap.jsx
@@ -95,7 +95,7 @@ export default function Treemap(props) {
   return (
     <>
       <div id="tooltip" className="tooltip-module" />
-      <div className="visContainer">
+      <div className={treemapStyles.treemapContainer}>
         <svg width="1200" height="700" viewBox="0 0 1200 700" id="treemapSvg" className={treemapStyles.treemapVisualization}/>
       </div>
     </>

--- a/src/components/visualizations/federal-employees/treemap/treemap.module.scss
+++ b/src/components/visualizations/federal-employees/treemap/treemap.module.scss
@@ -1,4 +1,30 @@
+@import '../../../../styles/variables.scss';
+
 .treemapVisualization {
   width: 100%;
   height: auto;
+}
+
+@media (min-width: $desktop) {
+  .treemapContainer {
+    height: 550px;
+  }
+}
+
+@media (min-width: $tablet) and (max-width: $desktop - 1) {
+  .treemapContainer {
+    height: 420px;
+  }
+}
+
+@media (min-width: $phone) and (max-width: $tablet - 1) {
+  .treemapContainer {
+    height: 315px;
+  }
+}
+
+@media (max-width: $phone) {
+  .treemapContainer {
+    height: 300px;
+  }
 }

--- a/src/page-sections/federal-employees/who.jsx
+++ b/src/page-sections/federal-employees/who.jsx
@@ -24,9 +24,6 @@ export default function Who(props) {
       <Share location={props.location} facebook='' reddit='' linkedin='' tumblr='' email='' />
     </ControlBar>
     <Treemap sectionId={props.sectionId} dataSource={props.dataSource} />
-    <Downloads
-      data={downloadableData}
-      isJSON={true}
-    />
+    <Downloads data={downloadableData} isJSON={true} />
   </>;
 }

--- a/src/pages/federal-employees/index.jsx
+++ b/src/pages/federal-employees/index.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import SEO from '../../components/seo';
-import '../../styles/index.scss';
 import fedEmpStyles from './index.module.scss';
 
 import DataModule from '../../components/visualizations/federal-employees/util/data-module';

--- a/src/pages/federal-employees/index.module.scss
+++ b/src/pages/federal-employees/index.module.scss
@@ -1,3 +1,5 @@
+@import '../../styles/index.scss';
+
 $fedEmpBlue: #2272CE;
 
 .headingBlue {


### PR DESCRIPTION
fix chart sizes in IE

https://federal-spending-transparency.atlassian.net/browse/DA-5469

IE uses different and nonsense default sizes for SVGs, so height: auto renders very small. This fix defines the containing element's height so the auto fills it.