### PR TITLE
fix column to row ie11 bug

### DIFF
--- a/src/components/layouts/faq/faq.jsx
+++ b/src/components/layouts/faq/faq.jsx
@@ -13,9 +13,9 @@ const FaqLayout = (props) => {
 
   if (!props.isCustomHeader) {
     header =
-      <div className={styles.header}>
+      <Grid container className={styles.header}>
         {props.heroImage ?
-         <Grid container justify='center' direction='column'>
+         <Grid container justify='center' direction='row'>
            <Grid item xs={12} className={styles.heroImage}>
              {props.heroImage}
            </Grid>
@@ -28,17 +28,17 @@ const FaqLayout = (props) => {
         </Grid>
         <Grid container justify='center'>
           <Grid item xs={11} md={10} xl={8}>
-            <header className={styles.headerHero} >
+            <div className={styles.headerHero} >
               <h1 className={styles.title}>
                 {props.title}
               </h1>
               <div className={styles.introSentence}>
                 {props.introSentence}
               </div>
-            </header>
+            </div>
           </Grid>
         </Grid>
-      </div>;
+      </Grid>;
   }
 
 
@@ -47,15 +47,17 @@ const FaqLayout = (props) => {
 
      <div className={styles.faqPage}>
        {header}
+
        <Grid container justify='center' className={styles.childrenContainer}>
          <Grid item xs={11} md={10} xl={8}>
            {props.children}
          </Grid>
        </Grid>
+
        <Grid container justify='center'>
          <Grid item xs={11} md={10}>
            <MoreAnalyses />
-         </Grid>
+         </Grid>         
        </Grid>
      </div>
 


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-5345

After poking around a bit and playing in the DOM on IE11 I have concluded that IE11 doesn't support MUI Grid `direction=column` well.

A quick change fixed this and does not alter other browsers.

https://github.com/mui-org/material-ui/issues/8854#issuecomment-340190712

Gotta love github issues (^: 