### PR TITLE
fix underline hyperlink

### DIFF
--- a/src/components/visualizations/dts/dts.scss
+++ b/src/components/visualizations/dts/dts.scss
@@ -389,6 +389,10 @@
     color: #574eca;
   }
 
+  .dts-hyperlink:hover {
+    text-decoration: underline;
+  };
+
   .dts-tt-amount {
     font-weight: 600;
     line-height: 25px;


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-5752

super quick add one line of css for hover (^: 