### PR TITLE
Federal Employees - Need to add "2 million" to the phrase "...employed nearly 2 million people."

### DIFF
--- a/src/pages/federal-employees/index.jsx
+++ b/src/pages/federal-employees/index.jsx
@@ -70,7 +70,7 @@ export default class FederalEmployeesPage extends Component {
 		return <StoryLayout
 			title={'Federal Employees'}
 			introSentence={'In 2017, the largest 24 federal agencies employed nearly 2 million people.'}
-			contextStatement={["The U.S. Treasury’s Data Lab presents an analysis exploring federal employees using federal financial data and employment data from the Office of Personnel Management (OPM). In 2017, the 24 CFO Act Agencies employed nearly people."]}
+			contextStatement={["The U.S. Treasury’s Data Lab presents an analysis exploring federal employees using federal financial data and employment data from the Office of Personnel Management (OPM). In 2017, the 24 CFO Act Agencies employed nearly 2 million people."]}
 			sectionToc={sections}
 			hwctaLink={this.props.location.pathname + '/methodologies'}
 		>


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-5721

Super quick update to Federal Employees header text.