### PR TITLE
adding prop to style fed employee page with proper spacing

### DIFF
--- a/src/components/control-bar/control-bar.jsx
+++ b/src/components/control-bar/control-bar.jsx
@@ -1,30 +1,29 @@
 import React, {Children} from 'react';
 import controlBarStyles from './control-bar.module.scss';
-import { Grid, Hidden } from "@material-ui/core"
-
+import { Grid, Hidden } from "@material-ui/core";
 
 const ControlBar = (props) => (
-   <>
+  <>
     <Hidden smUp>
-      <Grid container justify='space-evenly' className={controlBarStyles.controlBar}>
-          {Children.map(props.children, (child) => {
-              return <Grid className={controlBarStyles.child} item xs={2}>
-                      {child}
-                  </Grid>
-          })}
+      <Grid container justify='space-evenly' className={props.isFed ? controlBarStyles.fedControlBar : controlBarStyles.controlBar}>
+        {Children.map(props.children, (child) => {
+          return <Grid className={controlBarStyles.child} item xs={2}>
+                   {child}
+                 </Grid>;
+        })}
       </Grid>
     </Hidden>
     <Hidden xsDown>
-        <Grid container justify='flex-end' className={controlBarStyles.controlBar}>
-          {Children.map(props.children, (child) => {
-            return <Grid className={controlBarStyles.child} item sm={2}>
-                {child}
-              </Grid>
-          })}
-        </Grid>
+      <Grid container justify='flex-end' className={props.isFed ? controlBarStyles.fedControlBar : controlBarStyles.controlBar}>
+        {Children.map(props.children, (child) => {
+          return <Grid className={controlBarStyles.child} item sm={2}>
+                   {child}
+                 </Grid>;
+        })}
+      </Grid>
     </Hidden>
-   </>
+  </>
 );
 
 
-export default ControlBar
+export default ControlBar;

--- a/src/components/control-bar/control-bar.module.scss
+++ b/src/components/control-bar/control-bar.module.scss
@@ -5,6 +5,11 @@
   text-align: right;
 }
 
+.fedControlBar {
+  margin: 25px 0;
+  text-align: right;
+};
+
 .child {
   min-width: 5rem;
   span {

--- a/src/components/visualizations/federal-employees/mapviz/mapviz.jsx
+++ b/src/components/visualizations/federal-employees/mapviz/mapviz.jsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useState } from "react";
 import * as d3 from "d3v4";
 import Tooltip from "../util/tooltip";
 import mapStyles from './mapviz.module.scss';
-import Multiselector from "../../../multiselector/multiselector"
-import barChartStyles from "../bar-chart/bar-chart.module.scss"
-import ControlBar from "../../../control-bar/control-bar"
-import Reset from "../../../reset/reset"
-import Share from "../../../share/share"
+import Multiselector from "../../../multiselector/multiselector";
+import barChartStyles from "../bar-chart/bar-chart.module.scss";
+import ControlBar from "../../../control-bar/control-bar";
+import Reset from "../../../reset/reset";
+import Share from "../../../share/share";
 
 /* Extracted and adapted from fedscope.js an trreemap-module.js */
 
@@ -230,7 +230,7 @@ export default function Mapviz(props) {
 
   return (
     <>
-      <ControlBar>
+      <ControlBar isFed={true}>
         <Reset _resetClick={reset} />
         <Share location={props.location} />
       </ControlBar>

--- a/src/page-sections/federal-employees/what.jsx
+++ b/src/page-sections/federal-employees/what.jsx
@@ -5,7 +5,7 @@ import ControlBar from '../../components/control-bar/control-bar';
 import Reset from '../../components/reset/reset';
 import Share from '../../components/share/share';
 import BarChart from '../../components/visualizations/federal-employees/bar-chart/bar-chart';
-import Downloads from "../../components/section-elements/downloads/downloads"
+import Downloads from "../../components/section-elements/downloads/downloads";
 
 export default function What(props) {
 
@@ -21,15 +21,15 @@ export default function What(props) {
   });
 
   return <>
-    <h2>Federal Employee Bar Chart</h2>
-    <ControlBar>
-      <Reset />
-      <Share location={props.location} facebook='' reddit='' linkedin='' tumblr='' email='' />
-    </ControlBar>
-    <BarChart sectionId={props.sectionId} dataSource={props.dataSource} />
-    <Downloads
-      data={downloadableData}
-      isJSON={true}
-    />
-  </>;
+           <h2>Federal Employee Bar Chart</h2>
+           <ControlBar isFed={true}>
+             <Reset />
+             <Share location={props.location} facebook='' reddit='' linkedin='' tumblr='' email='' />
+           </ControlBar>
+           <BarChart sectionId={props.sectionId} dataSource={props.dataSource} />
+           <Downloads
+             data={downloadableData}
+             isJSON={true}
+           />
+         </>;
 }

--- a/src/page-sections/federal-employees/where.jsx
+++ b/src/page-sections/federal-employees/where.jsx
@@ -1,9 +1,9 @@
-import React from "react"
-import "../../styles/index.scss"
+import React from "react";
+import "../../styles/index.scss";
 
 /* components */
 import Mapviz from '../../components/visualizations/federal-employees/mapviz/mapviz';
-import Downloads from "../../components/section-elements/downloads/downloads"
+import Downloads from "../../components/section-elements/downloads/downloads";
 const employeesData = require('../../../static/unstructured-data/federal-employees/employees.json');
 
 function Where(props) {
@@ -17,7 +17,7 @@ function Where(props) {
         isJSON={true}
       />
     </>
-  )
+  );
 }
 
-export default Where
+export default Where;

--- a/src/page-sections/federal-employees/who.jsx
+++ b/src/page-sections/federal-employees/who.jsx
@@ -19,11 +19,11 @@ export default function Who(props) {
   });
 
   return <>
-    <h2>Spending by Agency</h2>
-    <ControlBar>
-      <Share location={props.location} facebook='' reddit='' linkedin='' tumblr='' email='' />
-    </ControlBar>
-    <Treemap sectionId={props.sectionId} dataSource={props.dataSource} />
-    <Downloads data={downloadableData} isJSON={true} />
-  </>;
+           <h2>Spending by Agency</h2>
+           <ControlBar isFed={true}>
+             <Share location={props.location} facebook='' reddit='' linkedin='' tumblr='' email='' />
+           </ControlBar>
+           <Treemap sectionId={props.sectionId} dataSource={props.dataSource} />
+           <Downloads data={downloadableData} isJSON={true} />
+         </>;
 }


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-5536

Adding a prop to distinguish between pages. The `ControlBar` for the Fed Employee page just needs to always use the `25px 0` margin instead of the desktop size one for pages with the `Accordion` component that will typically fill the space. 