### PR TITLE
dts cutoff fix tablet/mobile

### DIFF
--- a/src/components/visualizations/dts/dts.jsx
+++ b/src/components/visualizations/dts/dts.jsx
@@ -177,7 +177,7 @@ function DTS(props) {
     }
 
     function init() {
-      const w = 750;
+      const w = d3.select('.dts-layout-manager').node().getBoundingClientRect().width;
 
       d3.select('#svg-wrapper').attr('width', w);
 

--- a/src/components/visualizations/dts/dts.scss
+++ b/src/components/visualizations/dts/dts.scss
@@ -560,7 +560,7 @@
     }
 
     .dts-container {
-      width: 90%;
+      width: 100%;
     }
 
     #svg-wrapper {


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-5858

Fixing the cutoff where the bar would not resize. Working as it does in `prod` now.