### PR TITLE
dts tile spacing fix 

### DIFF
--- a/src/page-sections/home/dts-tile/landing-dts.scss
+++ b/src/page-sections/home/dts-tile/landing-dts.scss
@@ -19,19 +19,17 @@
 }
 
 .dtsm-dollars {
-  font-size: 1rem;
+  font-size: 1.375rem; // 22 px
   font-weight: 600;
-  margin-left: 15px;
-  margin-right: 15px;
-  /* opacity: .75; */
+  text-align: center;
   fill: #4A4A4A;
 }
 
 .dtsm-tas-header {
+  text-align: center;
   font-size: 0.75rem;
   font-weight: 600;
   line-height: 150%;
-  /* opacity: .8; */
   fill: #4A4A4A;
 }
 


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-6045

This is easy to test - if you are even feelin' a bit lazy and dont want to move the recent 30 file in local to test - you can edit the DOM raw on `qat` to see what im doing. Its two very small changes. (^: 

note: 22px is the default size of that in `prod` - just copied over.