### PR TITLE
move sunburst text so it doesn't overlap

### DIFF
--- a/src/components/visualizations/sunburst/sunburst.jsx
+++ b/src/components/visualizations/sunburst/sunburst.jsx
@@ -376,7 +376,6 @@ export default class Sunburst extends React.Component {
             <div id='investment-sunburst-viz'>
               <div id='sunburst'>
               </div>
-              <p className='cu-header__blurb'>To return to a higher level click the center node</p>
             </div>
           </div>
         </div>

--- a/src/page-sections/colleges-and-universities/categories/categories.jsx
+++ b/src/page-sections/colleges-and-universities/categories/categories.jsx
@@ -128,8 +128,8 @@ const Categories = () => {
         id: n.nodes[0].id,
         display: <><span className={styles.searchListFamily}>{n.nodes[0].family}</span><p className={styles.searchListProgram}>{n.nodes[0].Program_Title}</p></>,
         filterText: n.nodes[0].family + n.nodes[0].Program_Title,
-				heading: n.nodes[0].family,
-				subheading: n.nodes[0].Program_Title
+        heading: n.nodes[0].family,
+        subheading: n.nodes[0].Program_Title
       }))
       .sort(searchSort),
     grants: _data.grantsSearch.group
@@ -137,8 +137,8 @@ const Categories = () => {
         id: n.nodes[0].id,
         display: <><span className={styles.searchListFamily}>{n.nodes[0].family}</span><p className={styles.searchListProgram}>{n.nodes[0].Program_Title}</p></>,
         filterText: n.nodes[0].family + n.nodes[0].Program_Title,
-				heading: n.nodes[0].family,
-				subheading: n.nodes[0].Program_Title
+        heading: n.nodes[0].family,
+        subheading: n.nodes[0].Program_Title
       }))
       .sort(searchSort),
     research: _data.researchSearch.group
@@ -146,8 +146,8 @@ const Categories = () => {
         id: n.nodes[0].id,
         display: <><span className={styles.searchListFamily}>{n.nodes[0].family}</span><p className={styles.searchListProgram}>{n.nodes[0].Program_Title}</p></>,
         filterText: n.nodes[0].family + n.nodes[0].Program_Title,
-				heading: n.nodes[0].family,
-				subheading: n.nodes[0].Program_Title
+        heading: n.nodes[0].family,
+        subheading: n.nodes[0].Program_Title
       }))
       .sort(searchSort)
   };
@@ -199,7 +199,7 @@ const Categories = () => {
       <StoryHeading
         number={'04'}
         title={'Investment Categories'}
-        teaser={['How was the ',<span key='04-teaser-callout' className={storyHeadingStyles.headingRed}>money</span>, ' used?']}
+        teaser={['How was the ', <span key='04-teaser-callout' className={storyHeadingStyles.headingRed}>money</span>, ' used?']}
         blurb={`Now that we know how much money was invested in higher education, are you curious to know how the money was used? This visualization allows you to discover the various categories the government uses to classify funding. Note: Product and Service Codes (PSCs) are used to categorize contract purchases of products and services and Federal Assistance Listings are used to categorize grant funding.`}
       />
 
@@ -283,6 +283,7 @@ const Categories = () => {
             data={filteredTableData}
             tableRef={tableRef}
           />
+          <p className='cu-header__blurb'>To return to a higher level click the center node</p>
         </Grid>
       </Grid>
 


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-5934

I just moved this out properly, it was in the same `div` as the sunburst and caused it to overlap when shrunk. (^: 

