### PR TITLE
Barchart fixies - text overlapping/not displaying on IE11

### DIFF
--- a/src/components/visualizations/horizontal-barchart/barchart.jsx
+++ b/src/components/visualizations/horizontal-barchart/barchart.jsx
@@ -156,51 +156,55 @@ function Barchart(props) {
 
     let maxWidth = 0;
 
-    // y axis checkboxes
-    g.append('g')
-      .attr('class', 'axis axis--y')
-      .attr('y', 6)
-      .attr('dy', '0.71em')
-      .append('foreignObject')
-      .attr('id', 'yAxisForeignObject')
-      .attr('width', 500)
-      .attr('transform', 'translate(-500,0)')
-      .attr('height', 1000)
-      .append('xhtml:body')
-      .selectAll('.yAxisCheckbox')
+
+    // y axis - text
+    g
+      .append("g")
+      .attr("transform", `translate(-12,0)`)
+      .attr("class", "axis axis--y")
+      .call(
+        d3.svg
+          .axis()
+          .orient("left")
+          .scale(y)
+      )
+      .selectAll(".tick")
+      .attr("class", "yTick")
+      .selectAll("text")
+      .style("font-size", "12px");
+
+
+    // y checkboxes
+    g
+      .append("g")
+      .attr("class", "axis axis--y")
+      .attr("y", 6)
+      .attr("dy", "0.71em")
+      .append("foreignObject")
+      .attr("transform", "translate(-20,0)")
+      .attr("width", 22)
+      .attr("height", 1000)
+      .append("xhtml:body")
+      .append("form")
+      .attr("id", "yAxisCheckboxes")
+      .selectAll(".yAxisCheckbox")
       .data(sortedData)
       .enter()
-      .append('div')
-      .style('height', '21px')
+      .append("div")
+      .style("height", "21px")
+      .style("background", "white")
       .style('padding-top', '9px')
-      .style('background', 'white')
       .style('text-align', 'right')
-      .append('label')
-      .text((d) => d.name)
-      .attr('height', '21px')
-      .attr('width', function () {
-        const curWidth = this.getBoundingClientRect().width + 30;
-        if (curWidth > maxWidth) {
-          maxWidth = curWidth;
-        }
-        return curWidth + 'px';
-      })
-      .append('input')
-      .attr('type', 'checkbox')
-      .style('margin-left', '10px')
-      .attr('checked', (d) => (d.displayed ? true : null))
-      .attr('class', '.yAxisCheckbox')
-      .attr('id', (d) => `checkbox${d.id}`)
-      .on('click', (d) => {
+      .append("input")
+      .attr("type", "checkbox")
+      .attr("checked", (d) => (d.displayed ? true : null))
+      .attr("class", ".yAxisCheckbox")
+      .attr("id", (d) => `checkbox${d.id}`)
+      .on("click", (d) => {
         const { id } = d;
         const checked = svg.select(`#checkbox${id}`).node().checked;
         clickEvent(id, checked);
-      })
-      ;
-
-    g.select('#yAxisForeignObject')
-      .attr('width', (maxWidth + 25) + 'px')
-      .attr('transform', `translate(-${maxWidth + 25},0)`)
+      });
 
     const stackedDataset = d3.layout.stack()(
       keys.map((key) =>

--- a/src/components/visualizations/sunburst/sunburst.jsx
+++ b/src/components/visualizations/sunburst/sunburst.jsx
@@ -376,7 +376,6 @@ export default class Sunburst extends React.Component {
             <div id='investment-sunburst-viz'>
               <div id='sunburst'>
               </div>
-              <p className='cu-header__blurb'>To return to a higher level click the center node</p>
             </div>
           </div>
         </div>

--- a/src/page-sections/colleges-and-universities/categories/categories.jsx
+++ b/src/page-sections/colleges-and-universities/categories/categories.jsx
@@ -128,8 +128,8 @@ const Categories = () => {
         id: n.nodes[0].id,
         display: <><span className={styles.searchListFamily}>{n.nodes[0].family}</span><p className={styles.searchListProgram}>{n.nodes[0].Program_Title}</p></>,
         filterText: n.nodes[0].family + n.nodes[0].Program_Title,
-				heading: n.nodes[0].family,
-				subheading: n.nodes[0].Program_Title
+        heading: n.nodes[0].family,
+        subheading: n.nodes[0].Program_Title
       }))
       .sort(searchSort),
     grants: _data.grantsSearch.group
@@ -137,8 +137,8 @@ const Categories = () => {
         id: n.nodes[0].id,
         display: <><span className={styles.searchListFamily}>{n.nodes[0].family}</span><p className={styles.searchListProgram}>{n.nodes[0].Program_Title}</p></>,
         filterText: n.nodes[0].family + n.nodes[0].Program_Title,
-				heading: n.nodes[0].family,
-				subheading: n.nodes[0].Program_Title
+        heading: n.nodes[0].family,
+        subheading: n.nodes[0].Program_Title
       }))
       .sort(searchSort),
     research: _data.researchSearch.group
@@ -146,8 +146,8 @@ const Categories = () => {
         id: n.nodes[0].id,
         display: <><span className={styles.searchListFamily}>{n.nodes[0].family}</span><p className={styles.searchListProgram}>{n.nodes[0].Program_Title}</p></>,
         filterText: n.nodes[0].family + n.nodes[0].Program_Title,
-				heading: n.nodes[0].family,
-				subheading: n.nodes[0].Program_Title
+        heading: n.nodes[0].family,
+        subheading: n.nodes[0].Program_Title
       }))
       .sort(searchSort)
   };
@@ -199,7 +199,7 @@ const Categories = () => {
       <StoryHeading
         number={'04'}
         title={'Investment Categories'}
-        teaser={['How was the ',<span key='04-teaser-callout' className={storyHeadingStyles.headingRed}>money</span>, ' used?']}
+        teaser={['How was the ', <span key='04-teaser-callout' className={storyHeadingStyles.headingRed}>money</span>, ' used?']}
         blurb={`Now that we know how much money was invested in higher education, are you curious to know how the money was used? This visualization allows you to discover the various categories the government uses to classify funding. Note: Product and Service Codes (PSCs) are used to categorize contract purchases of products and services and Federal Assistance Listings are used to categorize grant funding.`}
       />
 
@@ -283,6 +283,7 @@ const Categories = () => {
             data={filteredTableData}
             tableRef={tableRef}
           />
+          <p className='cu-header__blurb'>To return to a higher level click the center node</p>
         </Grid>
       </Grid>
 


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-6046

Problem with text overlapping / the whole y-axis itself wasn't displaying at all on IE11, but displays on IE11 prod.

I reverted the code one to one with how it is on prod drawing the y-axis. It seems to work as expected.

I cannot test on IE11 as `localhost` rendering has a bug right now which is being compiled into commons.js and would take a little bit to find. I am **assuming** this works, as it is a one to one port.

If we push this branch to `qat` and it doesn't do anything, i can go back to this ticket. Tested on all browsers but IE11 locally. 