### PR TITLE
change global active link color

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -33,6 +33,10 @@ a:any-link {
   text-decoration: none;
 }
 
+a:active {
+  color: $specialState-active;
+}
+
 ul {
   max-height: none;
   overflow-y: inherit;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -23,7 +23,7 @@ $background-gray-warm-dark: #494440;
 $background-gray-warm-light: #e4e2e0;
 
 $specialState-focus: #3d94d0;
-$specialState-visited: #4c2c92;
+$specialState-active: #4c2c92;
 $specialState-highlight: #f2b733;
 $specialState-previous: #80b6f6;
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-6098

identified in homelessness, but actually should be site-wide