### PR TITLE
fix header top value on load for mobile

### DIFF
--- a/src/components/headers/page-mobile.scss
+++ b/src/components/headers/page-mobile.scss
@@ -23,11 +23,9 @@
     position: absolute;
     padding: 0;
     padding-right: 2rem;
-    right: 0;
-    top: 16px;
     width: auto;
+    right: 0;
     border-top: none;
-    height: 24px;
 
     #burger-menu {
       display: none;

--- a/src/components/headers/page.jsx
+++ b/src/components/headers/page.jsx
@@ -16,8 +16,8 @@ import { faBars } from '@fortawesome/free-solid-svg-icons';
 class PageHeader extends React.Component {
   constructor(props) {
     super(props);
-		// if we're NOT on the homepage...
-		// always set isSticky to true!
+    // if we're NOT on the homepage...
+    // always set isSticky to true!
     this.state = {
       isSticky: props.isHome === false ? true : false,
       isMobileTag: false,
@@ -31,15 +31,7 @@ class PageHeader extends React.Component {
     };
   };
 
-
-  handleResize = () => {
-    this.setState({windowWidw: window.innerWidth});
-  }
   componentDidMount() {
-
-    this.handleResize();
-
-    window.addEventListener('resize', this.handleResize());
 
     // check for mobile when window is avail...
     const isMobile = window.innerWidth < 475; // 475 arbitrary value when burger hits wall (position absolute!)
@@ -63,6 +55,10 @@ class PageHeader extends React.Component {
         }
         this.setState({ skinnyTop });
       });
+      
+      if (window.pageYOffset > 26) {
+        this.setState({skinnyTop: 0});
+      };
     }
 
 
@@ -77,7 +73,6 @@ class PageHeader extends React.Component {
         this.setState({ skinnySub });
       });
     }
-
   };
 
   handleMouseLeave = e => {


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-6089

Header gets a bit weird on page load when you are in the middle of the screen. 
This is due to dynamically settings values on scroll. 

If we are past the scroll threshold, the header will load back up at the top after the dom loads. 