### PR TITLE
determine window size after mount

### DIFF
--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -16,12 +16,13 @@ export default class RdInContractingPage extends React.Component {
     super(props);
 
     this.state = {
-      windowWidth: typeof window !== 'undefined' ? window.innerWidth : ''
+      windowWidth: null // can't get window size before rendering
     }
   }
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize);
+    this.handleResize();
   }
 
   componentWillUnmount() {
@@ -30,6 +31,11 @@ export default class RdInContractingPage extends React.Component {
 
   handleResize = () => {
     this.setState({ windowWidth: typeof window !== 'undefined' ? window.innerWidth : '' });
+
+console.log(window.innerWidth);
+
+
+
   }
 
   render = () =>

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -31,11 +31,6 @@ export default class RdInContractingPage extends React.Component {
 
   handleResize = () => {
     this.setState({ windowWidth: typeof window !== 'undefined' ? window.innerWidth : '' });
-
-console.log(window.innerWidth);
-
-
-
   }
 
   render = () =>

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -22,7 +22,7 @@ export default class RdInContractingPage extends React.Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize);
-    this.handleResize();
+    this.handleResize(); // determine correct initial legend layout
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
to use correct legend layout

https://federal-spending-transparency.atlassian.net/browse/DA-6196

this fixes using the mobile (stacked) layout initially, which only happened in server build