### PR TITLE
get rid of css target element

### DIFF
--- a/src/page-sections/rd-in-contracting/categories/categories.jsx
+++ b/src/page-sections/rd-in-contracting/categories/categories.jsx
@@ -10,6 +10,9 @@ export default function Categories() {
 
     const svg = categoryViz.select('svg');
 
+    svg
+      .attr('id', 'vizSvg');
+
     svg.selectAll('.category-icon')
       .attr('tabindex', 0)
       .style('cursor', 'pointer')

--- a/src/page-sections/rd-in-contracting/categories/categories.scss
+++ b/src/page-sections/rd-in-contracting/categories/categories.scss
@@ -1,4 +1,4 @@
-svg {
+#vizSvg {
   display: inline-block;
   position: relative;
   width: 100%;


### PR DESCRIPTION
* https://federal-spending-transparency.atlassian.net/browse/DA-6306

We put an element css selector )^:

Please try to not do this as the css gets compiled globally.
It is only safe to target an element directly if it is nested in a unique container. 