### PR TITLE
[8146] font styles for deficit/debt banner on overview page

### DIFF
--- a/src/afg-helpers/big-picture/scss/_deficit-debt-heading.scss
+++ b/src/afg-helpers/big-picture/scss/_deficit-debt-heading.scss
@@ -52,7 +52,21 @@
 }
 
 @media only screen and (min-width: 800px) {
-    .deficit-debt-heading {
-        padding: 65px 250px 15px;
+    .deficit-debt-heading__heading {
+        max-width: 750px;
+    }
+}
+
+@media only screen and (max-width: 799px) {
+    .deficit-debt-heading__heading {
+        font-size: 2rem;
+
+        .chapter__divider--text-deficit {
+            font-size: 2rem;
+        }
+        
+        .chapter__divider--text-debt {
+            font-size: 2rem;
+        }
     }
 }

--- a/src/afg-helpers/big-picture/scss/_deficit-debt-heading.scss
+++ b/src/afg-helpers/big-picture/scss/_deficit-debt-heading.scss
@@ -14,7 +14,8 @@
 
 .deficit-debt-heading__arrow-container {
     text-align: center;
-    margin: 10px 0;
+    margin-top: 15px;
+    font-size: 1.875rem;
 
     a {
         color:$text-color-paragraph;
@@ -27,17 +28,18 @@
 }
 
 .deficit-debt-heading__heading {
-    font-size: 2rem;
+    font-size: 2.5rem;
     font-weight: 300;
     background: #fff;
     color: #555;
     margin: 0 auto;
     max-width: 1000px;
-    padding: 15px;
+    padding: 25px 30px;
+    line-height: normal;
 
     strong, span {
         font-weight: $heavyBoldWeight;
-        font-size: 2rem;
+        font-size: 2.5rem;
     }
 }
 
@@ -51,10 +53,6 @@
 
 @media only screen and (min-width: 800px) {
     .deficit-debt-heading {
-        padding: 4rem 2rem 2rem;
-    }
-
-    .deficit-debt-heading__heading, .deficit-debt-heading__heading span {
-        @include baseHeaderDesktop();
+        padding: 65px 250px 15px;
     }
 }


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-8146

<img width="1290" alt="Screen Shot 2020-11-13 at 2 06 39 PM" src="https://user-images.githubusercontent.com/64594352/99111094-79593900-25b9-11eb-84f4-e8ef622c8910.png">