### PR TITLE
[7856] Tablet AFG sub-nav

### DIFF
--- a/src/components/afg-nav/afg-nav.jsx
+++ b/src/components/afg-nav/afg-nav.jsx
@@ -250,7 +250,7 @@ const AfgNav = ({ chapter }) => {
             const isMainSection = activeMainSection && activeMainSection.chapter === section.chapter;
             const subpageSection = activeSection ? sections.find((sec) => sec.chapter === activeSection.chapter) : { chapter: '', pages: [] };
 
-            const activeSubPageStyle = { height: 48 * section.pages.length, transition: '500ms height' };
+            const activeSubPageStyle = { height: 40 * section.pages.length, transition: '500ms height' };
             const inactiveSubPageStyle = { height: 0, margin: 0, transition: '500ms height' };
             const activeSubPageItemStyle = { opacity: 1, transition: '250ms opacity', transitionDelay: '500ms' };
             const inactiveSubPageItemStyle = { opacity: 0, transition: '250ms opacity', transitionDelay: '500ms', height: 0 };

--- a/src/components/afg-nav/afg-nav.module.scss
+++ b/src/components/afg-nav/afg-nav.module.scss
@@ -651,77 +651,7 @@
     }
 }
 
-@media only screen and (max-width: 991px) and (min-width: 660px) {
-    .chapter-nav {
-        min-height: auto;
-        height: 3rem;
-    }
-
-    .chapter-nav button {
-        display: none;
-    }
-
-    .menu-open .chapter-nav-overview {
-        border-bottom: none;
-    }
-
-    .chapter-nav ul {
-        display: flex;
-        width: 100%;
-        margin: 0 auto;
-    }
-
-    .chapter-nav li {
-        flex-grow: 1;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-
-    .chapter-nav.chapter-nav-deficit li {
-        width: 33%;
-    }
-
-    .chapter-nav li:last-of-type {
-        border-right: none;
-    }
-
-    .chapter-nav li a, .chapter-nav li.active a {
-        height: auto;
-        text-align: center;
-        line-height: normal;
-    }
-
-    .chapter-nav-active-list {
-        max-width: calc(992px - 22.5%);
-
-        li {
-            padding: 0 5px;
-        }
-    }
-
-    .chapter-nav-primary-list {
-        .inactive-section {
-            max-width: 12.5%;
-            min-width: 85px;
-
-            .section-name {
-                max-width: 80%;
-            }
-        }
-
-        .chapter-nav-overview {
-            max-width: 45px;
-            min-width: 45px;
-
-            .section-name {
-                display: none;
-            }
-        }
-    }
-}
-
-@media only screen and (max-width: 659px) {
+@media only screen and (max-width: 991px) {
     .chapter-nav-container {
         position: relative;
         margin-top: 50px;
@@ -805,6 +735,7 @@
                 }
                 
                 .sub-page {
+                    height: 40px;
                     font-size: 0.875rem;
 
                     &.active-sub-page {
@@ -855,6 +786,12 @@
             background-color: #ebe9e9;
             font-size: 1.5rem;
         }
+    }
+}
+
+@media only screen and (max-width: 991px) and (min-width: 768px) {
+    .chapter-nav-container {
+        margin-top: 48px;
     }
 }
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-7856

After meeting again, we decided to use the mobile menu for tablets as well, so the current tablet mocks in InVision and Zeplin are inaccurate - just use the mobile ones

Overview (closed):
<img width="617" alt="Screen Shot 2020-12-10 at 12 22 10 PM" src="https://user-images.githubusercontent.com/64594352/101806870-7bdc7f00-3ae2-11eb-82f9-fbebec5c163f.png">

Overview (open):
<img width="617" alt="Screen Shot 2020-12-10 at 12 22 14 PM" src="https://user-images.githubusercontent.com/64594352/101806878-7e3ed900-3ae2-11eb-949b-18b835a08030.png">

Specific page (closed):
<img width="617" alt="Screen Shot 2020-12-10 at 12 22 45 PM" src="https://user-images.githubusercontent.com/64594352/101806891-80a13300-3ae2-11eb-97ac-a7a8bec03100.png">

Specific page (open):
<img width="617" alt="Screen Shot 2020-12-10 at 12 22 49 PM" src="https://user-images.githubusercontent.com/64594352/101806901-839c2380-3ae2-11eb-94d2-1db540f46861.png">
