### PR TITLE
[8430|8426] Tablet sub-nav fixes/make active chevron larger at all times

### DIFF
--- a/src/components/afg-nav/afg-nav.jsx
+++ b/src/components/afg-nav/afg-nav.jsx
@@ -118,6 +118,7 @@ const AfgNav = ({ chapter }) => {
   const [screenMode, setScreenMode] = useState(0);
   const [activeSection, setActiveSection] = useState(sections.find((s) => s.chapter === chapter));
   const [activeMainSection, setActiveMainSection] = useState(sections.find((s) => s.chapter === chapter));
+  const [activeMainSectionClosed, setActiveMainSectionClosed] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [activeSubPage, setActiveSubPage] = useState('');
   const [isMounted, setIsMounted] = useState(false);
@@ -159,7 +160,19 @@ const AfgNav = ({ chapter }) => {
 
   const handleActiveSectionChange = (e) => {
     const section = sections.find((s) => s.name === e.target.textContent);
+
+    if (activeSection && activeMainSection && section.name === activeMainSection.name && activeSection.name === activeMainSection.name) {
+      setActiveMainSectionClosed((prevState) => !prevState);
+    } else if (activeSection && section.name === activeSection.name) {
+      setActiveSection(activeMainSection);
+      setActiveMainSectionClosed(false);
+    } else {
+      setActiveSection(section);
+      setActiveMainSectionClosed(false);
+    }
+
     setActiveSection(activeSection && section.name === activeSection.name ? activeMainSection : section);
+
     if (activeMainSection && activeSection && activeSection.name !== activeMainSection.name) {
       setIsLarger(section.name);
     }
@@ -196,7 +209,7 @@ const AfgNav = ({ chapter }) => {
                 />
                 Overview
               </a>
-              {screenMode >= ScreenModeEnum.desktop && (isLarger === 'Overview' || (!isLarger && !activeMainSection)) && <div className={style.sectionNameExtension} />}
+              {screenMode >= ScreenModeEnum.desktop && (isLarger === 'Overview' || !activeMainSection) && <div className={style.sectionNameExtension} />}
             </div>
           </li>
           {screenMode >= ScreenModeEnum.desktop && sections.map((section) => {
@@ -209,7 +222,7 @@ const AfgNav = ({ chapter }) => {
             const activeSubPageItemStyle = { opacity: 1, transition: '250ms opacity', transitionDelay: '500ms' };
             const inactiveSubPageItemStyle = { opacity: 0, transition: '250ms opacity', transitionDelay: '500ms', width: 0 };
 
-            const larger = isLarger === section.name || (isLarger === '' && activeMainSection && activeMainSection.name === section.name);
+            const larger = isLarger === section.name || (activeMainSection && activeMainSection.name === section.name);
 
             return (
               <>
@@ -273,13 +286,13 @@ const AfgNav = ({ chapter }) => {
                 </li>
                 <li
                   className={`${style.chapterNavSubPages} ${!isMenuOpen || !isActive ? style.closed : ''}`}
-                  style={isActive ? activeSubPageStyle : inactiveSubPageStyle}
+                  style={isActive && !activeMainSectionClosed ? activeSubPageStyle : inactiveSubPageStyle}
                 >
                   <ul className={screenMode <= ScreenModeEnum.tablet && activeSection ? activeSection.transparentColorClass : ''}>
                     {subpageSection.pages.map((page) => (
                       <li
                         className={`${style.subPage} ${page.url === activeSubPage ? style.activeSubPage : ''} ${!isMenuOpen || !isActive ? style.closed : ''}`}
-                        style={isActive ? activeSubPageItemStyle : inactiveSubPageItemStyle}
+                        style={isActive && !activeMainSectionClosed ? activeSubPageItemStyle : inactiveSubPageItemStyle}
                       >
                         <a className={screenMode >= ScreenModeEnum.desktop ? activeSection.colorClass : ''} href={page.url}>
                           {page.name}

--- a/src/components/afg-nav/afg-nav.module.scss
+++ b/src/components/afg-nav/afg-nav.module.scss
@@ -167,19 +167,6 @@
             border-top: 5px solid #082548;
         }
     }
-    
-    &:hover {
-        background-color: #082548;
-
-        .section-name:before {
-            border-left: 4px solid #082548;
-        }
-        
-            .section-name-extension {
-                border-top: 5px solid #082548;
-            }
-
-    }
 }
 
 .chapter-nav-spending {
@@ -205,19 +192,6 @@
         .section-name-extension {
             border-top: 5px solid #005E56;
         }
-    }
-    
-    &:hover {
-        background-color: #005E56;
-
-        .section-name:before {
-            border-left: 4px solid #005E56;
-        }
-        
-            .section-name-extension {
-                border-top: 5px solid #005E56;
-            }
-
     }
 }
 
@@ -245,19 +219,6 @@
             border-top: 5px solid #9F4224;
         }
     }
-    
-    &:hover {
-        background-color: #9F4224;
-
-        .section-name:before {
-            border-left: 4px solid #9F4224;
-        }
-        
-            .section-name-extension {
-                border-top: 5px solid #9F4224;
-            }
-
-    }
 }
 
 .chapter-nav-debt {
@@ -283,19 +244,6 @@
         .section-name-extension {
             border-top: 5px solid #3B005B;
         }
-    }
-    
-    &:hover {
-        background-color: #3B005B;
-
-        .section-name:before {
-            border-left: 4px solid #3B005B;
-        }
-        
-            .section-name-extension {
-                border-top: 5px solid #3B005B;
-            }
-
     }
 }
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-8430
https://federal-spending-transparency.atlassian.net/browse/DA-8426

Active section on tablet can be closed:
<img width="606" alt="Screen Shot 2020-12-11 at 3 15 32 PM" src="https://user-images.githubusercontent.com/64594352/101950715-b8cc7280-3bc3-11eb-8be6-a989059871fb.png">

Colors fixed (before/after):
<img width="606" alt="Screen Shot 2020-12-11 at 3 17 00 PM" src="https://user-images.githubusercontent.com/64594352/101950856-fc26e100-3bc3-11eb-9560-f23c155c7205.png">
<img width="606" alt="Screen Shot 2020-12-11 at 3 17 07 PM" src="https://user-images.githubusercontent.com/64594352/101950859-fd580e00-3bc3-11eb-9a2e-e4e703a4f04c.png">

Active section chevron is always larger:
<img width="1177" alt="Screen Shot 2020-12-11 at 3 14 27 PM" src="https://user-images.githubusercontent.com/64594352/101950620-920e3c00-3bc3-11eb-94cb-3a17dadd7008.png">
