### PR TITLE
[7854] Show AFG sub-nav when scrolling up

### DIFF
--- a/src/components/afg-nav/afg-nav.jsx
+++ b/src/components/afg-nav/afg-nav.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome, faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 import { checkAfgScreenMode, ScreenModeEnum } from 'src/utils/screen-mode';
-// import { lg } from 'src/styles/variables.scss';
+import { lg } from 'src/styles/variables.scss';
 import style from './afg-nav.module.scss';
 
 const AfgNav = ({ chapter }) => {
@@ -114,7 +114,9 @@ const AfgNav = ({ chapter }) => {
     },
   ];
 
-  // const [stickyStyle, setStickyStyle] = useState({ marginTop: '3rem' });
+  const [stickyStyle, setStickyStyle] = useState({});
+  const [scrollPosition, setScrollPosition] = useState(0);
+  const [pauseScrollListener, setPauseScrollListener] = useState(0);
   const [screenMode, setScreenMode] = useState(0);
   const [activeSection, setActiveSection] = useState(sections.find((s) => s.chapter === chapter));
   const [activeMainSection, setActiveMainSection] = useState(sections.find((s) => s.chapter === chapter));
@@ -124,14 +126,6 @@ const AfgNav = ({ chapter }) => {
   const [isLarger, setIsLarger] = useState('');
 
   useEffect(() => {
-    // const marginTop = window.innerWidth < lg ? 50 : '3rem';
-
-    // const scrollListener = () => {
-    //   setStickyStyle(window.pageYOffset > 26 && window.innerWidth >= lg ? { position: 'sticky', top: 50 } : { marginTop });
-    // };
-
-    // window.addEventListener('scroll', scrollListener);
-
     const resizeWindow = () => {
       const newMode = checkAfgScreenMode(window.innerWidth);
       if (newMode !== screenMode) {
@@ -157,6 +151,27 @@ const AfgNav = ({ chapter }) => {
     setIsMounted(true);
   }, []);
 
+  useEffect(() => {
+    setScrollPosition(window.pageYOffset);
+
+    const scrollPositionListener = () => {
+      setScrollPosition(window.pageYOffset);
+    };
+
+    const scrollListener = () => {
+      if (!isMenuOpen) {
+        if (window.pageYOffset < scrollPosition) {
+          setStickyStyle(window.pageYOffset > 26 ? { position: 'sticky', top: 50 } : {});
+        } else {
+          setStickyStyle({});
+        }
+      }
+    };
+
+    window.addEventListener('scroll', scrollPositionListener);
+    window.addEventListener('scroll', scrollListener);
+  }, [scrollPosition]);
+
   const handleActiveSectionChange = (e) => {
     const section = sections.find((s) => s.name === e.target.textContent);
     setActiveSection(activeSection && section.name === activeSection.name ? activeMainSection : section);
@@ -179,7 +194,7 @@ const AfgNav = ({ chapter }) => {
   };
 
   return (
-    <div className={`${style.chapterNavContainer} ${!isMenuOpen ? style.chapterNavContainerClosed : style.chapterNavContainerOpen}`}>
+    <div className={`${style.chapterNavContainer} ${!isMenuOpen ? style.chapterNavContainerClosed : style.chapterNavContainerOpen}`} style={stickyStyle}>
       <nav className={style.chapterNav}>
         <ul className={style.chapterNavPrimaryList}>
           <li

--- a/src/components/afg-nav/afg-nav.jsx
+++ b/src/components/afg-nav/afg-nav.jsx
@@ -116,7 +116,6 @@ const AfgNav = ({ chapter }) => {
 
   const [stickyStyle, setStickyStyle] = useState({});
   const [scrollPosition, setScrollPosition] = useState(0);
-  const [pauseScrollListener, setPauseScrollListener] = useState(0);
   const [screenMode, setScreenMode] = useState(0);
   const [activeSection, setActiveSection] = useState(sections.find((s) => s.chapter === chapter));
   const [activeMainSection, setActiveMainSection] = useState(sections.find((s) => s.chapter === chapter));
@@ -159,12 +158,14 @@ const AfgNav = ({ chapter }) => {
     };
 
     const scrollListener = () => {
-      if (!isMenuOpen) {
-        if (window.pageYOffset < scrollPosition) {
-          setStickyStyle(window.pageYOffset > 26 ? { position: 'sticky', top: 50 } : {});
-        } else {
+      if (window.pageYOffset > 26) {
+        if (screenMode >= ScreenModeEnum.desktop && window.pageYOffset > scrollPosition) {
           setStickyStyle({});
+        } else {
+          setStickyStyle({ position: 'sticky', top: 50 });
         }
+      } else {
+        setStickyStyle({});
       }
     };
 
@@ -268,7 +269,7 @@ const AfgNav = ({ chapter }) => {
             const activeSubPageStyle = { height: 40 * section.pages.length, transition: '500ms height' };
             const inactiveSubPageStyle = { height: 0, margin: 0, transition: '500ms height' };
             const activeSubPageItemStyle = { opacity: 1, transition: '250ms opacity', transitionDelay: '500ms' };
-            const inactiveSubPageItemStyle = { opacity: 0, transition: '250ms opacity', transitionDelay: '500ms', height: 0 };
+            const inactiveSubPageItemStyle = { height: 0, opacity: 0, transition: '250ms opacity', transitionDelay: '500ms' };
 
             let activeSubPageName = section.name;
 

--- a/src/components/afg-nav/afg-nav.module.scss
+++ b/src/components/afg-nav/afg-nav.module.scss
@@ -338,7 +338,6 @@
     line-height: 3rem;
     overflow: hidden;
     opacity: 1;
-    transition: height 0.3s ease;
 
     .section-name {
         color: white;
@@ -691,7 +690,6 @@
     
             .chapter-nav-overview, .active-section, .inactive-section {
                 height: 40px;
-                transition: 500ms height;
                 text-transform: uppercase;
     
                 .section-name {

--- a/src/components/afg-nav/afg-nav.module.scss
+++ b/src/components/afg-nav/afg-nav.module.scss
@@ -48,6 +48,10 @@
     background-color: rgba(74, 0, 114, 0.1);
 }
 
+.chapter-nav-container {
+    z-index: 20;
+}
+
 .chapter-nav {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-7854

sub-nav should be sticky all the time on tablet/mobile, and whenever you scroll down and scroll back up on desktop



