### PR TITLE
[8451] TOC New and Coming Soon flags

### DIFF
--- a/src/components/toc/toc.jsx
+++ b/src/components/toc/toc.jsx
@@ -1,93 +1,139 @@
 import React, { useState, useEffect } from 'react';
 import { Grid } from '@material-ui/core';
 import PropTypes from 'prop-types';
-import styleVariables from '../../styles/variables.scss';
-import styles from './toc.module.scss';
 import { ScreenModeEnum, checkScreenMode } from 'src/utils/screen-mode';
+import styles from './toc.module.scss';
 
-const Toc = (props) => {
-	const [selectedStyle, setSelectedStyle] = useState('');
-	const inlineStyles = {
-		legacy: 'legacy',
-		'colleges-and-universities': 'collegesAndUniversities',
-		'federal-covid-funding': 'federalCovidFunding',
-		'homelessness-analysis': 'homelessnessAnalysis',
-	}
+const Toc = ({ sections }) => {
+  const [selectedStyle, setSelectedStyle] = useState('');
+  const inlineStyles = {
+    legacy: 'legacy',
+    'colleges-and-universities': 'collegesAndUniversities',
+    'federal-covid-funding': 'federalCovidFunding',
+    'homelessness-analysis': 'homelessnessAnalysis',
+  };
 
-	const [screenMode, setScreenMode] = useState(0);
+  const [screenMode, setScreenMode] = useState(0);
 
-	const resizeWindow = () => {
-		const newMode = checkScreenMode(window.innerWidth);
-		if (newMode !== screenMode) {
-			setScreenMode(newMode);
-		}
-	}
-		
-	useEffect(() => {
-		if (typeof window !== 'undefined') {
-			const pathname = window.location.pathname.replace(/\//g, '');
-			const index = Object.keys(inlineStyles).indexOf(pathname);
-		
-			if (index > -1) {
-				setSelectedStyle(inlineStyles[pathname]);
-			} else {
-				setSelectedStyle(inlineStyles.legacy)
-			}
+  const resizeWindow = () => {
+    const newMode = checkScreenMode(window.innerWidth);
+    if (newMode !== screenMode) {
+      setScreenMode(newMode);
+    }
+  };
 
-			resizeWindow();
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const pathname = window.location.pathname.replace(/\//g, '');
+      const index = Object.keys(inlineStyles).indexOf(pathname);
+
+      if (index > -1) {
+        setSelectedStyle(inlineStyles[pathname]);
+      } else {
+        setSelectedStyle(inlineStyles.legacy);
+      }
+
+      resizeWindow();
       window.addEventListener('resize', resizeWindow);
       return () => {
         window.removeEventListener('resize', resizeWindow);
-      }
-		}
-	})
+      };
+    }
+  });
 
-	const anchorClassName = `${selectedStyle}Anchor`
-	const sectionClassName = `${selectedStyle}Section`
+  const anchorClassName = `${selectedStyle}Anchor`;
+  const sectionClassName = `${selectedStyle}Section`;
 
-	const lgGridSize = props.sections.length <= 4 ? (12 / props.sections.length) : 3;
+  const lgGridSize = sections.length <= 4 ? (12 / sections.length) : 3;
 
-	const isTablet = screenMode === ScreenModeEnum.tablet;
+  const isTablet = screenMode === ScreenModeEnum.tablet;
+  const isMobile = screenMode === ScreenModeEnum.mobile;
 
-	return (
-		<section id={styles.TOC}>
-			<Grid container className={styles.container}>
-				{props.sections.map((item, key) => (
-					<Grid item key={key} className={styles.tile} xs={12} md={6} lg={lgGridSize}>
-						<a href={`#section-${item.anchor}`} className={styles[anchorClassName]}>
-							<Grid
-								container
-								justify={isTablet ? "flex-start" : "center"}
-								className={`${styles.content} ${isTablet && key <= 1 ? styles.bottomBorder : ''}`}
-							>
-								<Grid item className={styles.a}>
-									<Grid container className={styles.numberContainer}>
-										<Grid item xs={2} lg={3} className={styles.number}>
-											{item.number}
-										</Grid>
-										<Grid item className={styles.section}>
-											<span className={styles[sectionClassName]}>{item.section}</span>
-										</Grid>
-									</Grid>
-									<Grid item>
-										<div className={styles.subblurb}>{item.subblurb}</div>
-										<div className={styles.blurb}>{item.blurb}</div>
-									</Grid>
-								</Grid>
-							</Grid>
-							{screenMode === ScreenModeEnum.tablet &&
-								<div className={`${styles.tabletDivider} ${isTablet && (key === 0 || key === 2) ? styles.sideBorder : ''}`} />
-							}
-						</a>
-					</Grid>
-				))}
-			</Grid>
-		</section>
-	)
+  return (
+    <section id={styles.TOC}>
+      <Grid container className={styles.container}>
+        {sections.map((section, key) => {
+          const LinkWrapper = ({ children }) => (
+            section.comingSoon
+              ? (
+                <div className={styles.linkContainer}>
+                  {children}
+                </div>
+              ) : (
+                <a
+                  href={`#section-${section.anchor}`}
+                  className={`${styles[anchorClassName]} ${styles.linkContainer}`}
+                >
+                  {children}
+                </a>
+              )
+          );
+
+          const mobileStyle = {};
+          if (!section.isNew) {
+            mobileStyle.paddingLeft = 50;
+          }
+          if (section.comingSoon) {
+            mobileStyle.flexDirection = 'row-reverse';
+          }
+
+          return (
+            <Grid item key={key} className={styles.tile} xs={12} md={6} lg={lgGridSize}>
+              <LinkWrapper>
+                <Grid
+                  container
+                  justify={isTablet ? 'flex-start' : 'center'}
+                  className={`${styles.content} ${isTablet && key <= 1 ? styles.bottomBorder : ''} ${isTablet && key >= 2 ? styles.topPadding : ''}`}
+                  style={isMobile ? mobileStyle : {}}
+                >
+                  <Grid item className={styles.newFlagContainer}>
+                    {section.isNew && (
+                    <div className={styles.newFlag}>
+                      New
+                    </div>
+                    )}
+                    {section.comingSoon && (
+                    <Grid item className={styles.comingSoon}>
+                      Coming Soon!
+                    </Grid>
+                    )}
+                  </Grid>
+                  <Grid item className={styles.a}>
+                    <Grid container className={styles.numberContainer}>
+                      <Grid item xs={2} lg={3} className={`${styles.number} ${section.comingSoon ? styles.faded : ''}`}>
+                        {section.number}
+                      </Grid>
+                      <Grid item className={styles.section}>
+                        <span className={`${styles[sectionClassName]} ${section.comingSoon ? styles.faded : ''}`}>
+                          {section.section}
+                        </span>
+                      </Grid>
+                    </Grid>
+                    <Grid item>
+                      <div className={`${styles.subblurb} ${section.comingSoon ? styles.faded : ''}`}>
+                        {section.subblurb}
+                      </div>
+                      <div className={styles.blurb}>{section.blurb}</div>
+                    </Grid>
+                  </Grid>
+                </Grid>
+                {screenMode === ScreenModeEnum.tablet
+                && <div className={`${styles.tabletDivider} ${isTablet && (key === 0 || key === 2) ? styles.sideBorder : ''}`} />}
+              </LinkWrapper>
+            </Grid>
+          );
+        })}
+      </Grid>
+    </section>
+  );
 };
 
 Toc.propTypes = {
-	sections: PropTypes.arrayOf(PropTypes.object),
+  sections: PropTypes.arrayOf(PropTypes.object),
+};
+
+Toc.defaultProps = {
+  sections: [],
 };
 
 export default Toc;

--- a/src/components/toc/toc.module.scss
+++ b/src/components/toc/toc.module.scss
@@ -36,9 +36,44 @@ $mdGrey: #555555;
     margin-top: 10px;
   }
 
+  .new-flag-container {
+    display: flex;
+    align-items: center;
+    height: 40px;
+
+    .new-flag {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      position: relative;
+      color: #fff;
+      background-color: $legacyBlue;
+      text-transform: uppercase;
+      font-weight: bold;
+  
+      &:before {
+        content: "";
+        height: 0;
+        left: 0;
+        position: absolute;
+        width: 0;
+      }
+    }
+  }
+
+  .coming-soon {
+    display: flex;
+    align-items: flex-end;
+    height: 40px;
+    font-size: 1rem;
+    font-weight: bold;
+    font-style: italic;
+    color: black;
+  }
+
   .legacy-anchor:hover {
     color: $legacyBlue;
-    * {
+    .a {
       color: $legacyBlue !important;
       text-decoration: underline;
     }
@@ -46,7 +81,7 @@ $mdGrey: #555555;
 
   .colleges-and-universities-anchor:hover {
     color: $cuRed;
-    * {
+    .a {
       color: $cuRed !important;
       text-decoration: underline;
     }
@@ -54,7 +89,7 @@ $mdGrey: #555555;
 
   .federal-covid-funding-anchor:hover {
     color: $covidPurple;
-    * {
+    .a {
       color: $covidPurple !important;
       text-decoration: underline;
     }
@@ -62,7 +97,7 @@ $mdGrey: #555555;
 
   .homelessness-analysis-anchor:hover {
     color: $homelessAnalysisPurple;
-    * {
+    .a {
       color: $homelessAnalysisPurple !important;
       text-decoration: underline;
     }
@@ -83,6 +118,15 @@ $mdGrey: #555555;
   .homelessness-analysis-section {
     color: $homelessAnalysisPurple;
   }
+
+  .faded {
+    opacity: 0.7;
+    
+    &:not(.number) {
+      font-style: italic;
+      font-weight: 400;
+    }
+  }
 }
 
 
@@ -91,6 +135,10 @@ $mdGrey: #555555;
   #TOC {
     margin-top: $margin-75;
     margin-bottom: $margin-100;
+
+    .content {
+      flex-direction: column;
+    }
 
     .container {
       justify-content: space-around;
@@ -102,6 +150,45 @@ $mdGrey: #555555;
     .tile {
       padding: 1rem 1.5rem;
     }
+
+    .a {
+      margin-top: 10px;
+    }
+
+    .new-flag-container {
+      width: 100%;
+
+      .new-flag {
+        height: 30px;
+        width: 44px;
+        font-size: 1rem;
+
+        &::before {
+          border-top: 12px solid $legacyBlue;
+          border-left: 22px solid transparent;
+          border-right: 22px solid transparent;
+          top: 30px;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: $desktop - 1) {
+  .new-flag {
+    height: 25px;
+    width: 36px;
+
+    &::before {
+      border-top: 8px solid $legacyBlue;
+      border-left: 18px solid transparent;
+      border-right: 18px solid transparent;
+      top: 25px;
+    }
+  }
+
+  .coming-soon {
+    align-items: center;
   }
 }
 
@@ -118,6 +205,10 @@ $mdGrey: #555555;
       }
     }
 
+    .content {
+      flex-direction: column;
+    }
+
     .a {
       max-width: 250px;
     }
@@ -126,7 +217,7 @@ $mdGrey: #555555;
       min-height: 50%;
 
       &:nth-child(even) {
-        a {
+        .link-container {
           flex-direction: row-reverse;
         }
       }
@@ -135,12 +226,12 @@ $mdGrey: #555555;
         border-right: none;
       }
 
-      a {
+      .link-container {
         display: flex;
         height: 100%;
 
         .content {
-          padding: 1rem 0 1.875rem;
+          padding-bottom: 1.875rem;
         }
 
         .bottom-border {
@@ -151,10 +242,18 @@ $mdGrey: #555555;
           border-right: 1px solid $light-grey-border;
         }
 
+        .top-padding {
+          padding-top: 20px;
+        }
+
         .tablet-divider {
           width: 15px;
         }
       }
+    }
+
+    .new-flag-container {
+      align-items: flex-start;
     }
   }
 }
@@ -162,7 +261,8 @@ $mdGrey: #555555;
 @media (max-width: $tablet - 1) {
   #TOC {
     .a {
-      width: 100%;
+      display: flex;
+      flex-grow: 1;
     }
     .tile {
       border-right: unset;
@@ -181,6 +281,10 @@ $mdGrey: #555555;
     margin-bottom: $margin-25;
     margin-top: $margin-25;
 
+    .content {
+      margin-bottom: 10px;
+    }
+
     .tile {
       padding: 0;
       border: none;
@@ -192,12 +296,28 @@ $mdGrey: #555555;
       font-size: 1.5rem;
       line-height: 3.125rem;
       margin: 0;
+      max-width: 40px;
+      min-width: 40px;
     }
     .section {
       margin: auto 0;
     }
     .blurb {
       text-transform: uppercase;
+    }
+
+    .new-flag-container {
+      height: 50px;
+      align-items: center;
+      
+      .new-flag {
+        width: 36px;
+        margin-right: 14px;
+      }
+
+      .coming-soon  {
+        height: 22px;
+      }
     }
   }
 }

--- a/src/components/toc/toc.module.scss
+++ b/src/components/toc/toc.module.scss
@@ -65,7 +65,6 @@ $mdGrey: #555555;
     display: flex;
     align-items: flex-end;
     height: 40px;
-    font-size: 1rem;
     font-weight: bold;
     font-style: italic;
     color: black;
@@ -120,11 +119,11 @@ $mdGrey: #555555;
   }
 
   .faded {
-    opacity: 0.7;
+    opacity: 0.6;
     
     &:not(.number) {
       font-style: italic;
-      font-weight: 400;
+      font-weight: 300;
     }
   }
 }
@@ -189,6 +188,7 @@ $mdGrey: #555555;
 
   .coming-soon {
     align-items: center;
+    font-size: 0.75rem;
   }
 }
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-8451

in order to see the flags, add `isNew: true` or `comingSoon: true` as a prop to any of the sections on index.jsx for any page that uses the TOC component (ex. [here](https://github.com/fedspendingtransparency/datalab/blob/dev/src/pages/federal-covid-funding/index.jsx#L53)). in the future, we'll have it based on a date, but for demonstration it can just be true

desktop:
<img width="1151" alt="Screen Shot 2020-12-22 at 11 01 25 AM" src="https://user-images.githubusercontent.com/64594352/102908485-89c8c300-4445-11eb-9ba1-c4768e33c0b4.png">

tablet:
<img width="607" alt="Screen Shot 2020-12-22 at 11 01 40 AM" src="https://user-images.githubusercontent.com/64594352/102908493-8d5c4a00-4445-11eb-81e6-48fa50c341c6.png">

mobile:
<img width="423" alt="Screen Shot 2020-12-22 at 11 02 06 AM" src="https://user-images.githubusercontent.com/64594352/102908503-8fbea400-4445-11eb-89a2-68662cde012a.png">
