### PR TITLE
8518 removed code for special characters that is no longer needed; al…

### DIFF
--- a/src/afg-helpers/countries/data.js
+++ b/src/afg-helpers/countries/data.js
@@ -46,23 +46,6 @@ function setSort(sortField) {
   }
 }
 
-function handleSpecialCharacterCountries(countryName) {
-  let curCountry = countryName;
-  if (curCountry) {
-    // Currently we only have one country with any special characters, but in any chance we run across more countries
-    // with special characters, we should have a place to put them.
-    switch (curCountry.toLowerCase()) {
-      case 'côte d\'ivoire':
-        curCountry = 'Cote d\'Ivoire'; // Plain language for typing purposes.
-        break;
-      default:
-        break;
-    }
-  }
-
-  return curCountry;
-}
-
 export function getCountryList() {
   return masterData.countryList;
 }
@@ -77,8 +60,6 @@ export function prepareData(_config, first) {
   activeSortField = config.amountField;
 
   sourceData.forEach((r) => {
-    const curCountry = handleSpecialCharacterCountries(r.country);
-
     let isCountryAdded = false;
     masterData.countryList.forEach((country) => {
       if (country.display === r.country) {
@@ -89,7 +70,6 @@ export function prepareData(_config, first) {
     if (!isCountryAdded) {
       masterData.countryList.push({
         display: r.country,
-        plainName: curCountry,
       });
     }
 

--- a/src/afg-helpers/countries/selectCountry.js
+++ b/src/afg-helpers/countries/selectCountry.js
@@ -184,13 +184,9 @@ function getAvailableCountries(filterStr) {
         if (!c) {
           return false;
         }
-        const plainName = c.plainName,
-            displayName = c.display;
-        // The first check makes sure to exclude any countries we already have selected, the second checks both the "plain name"
-        // of each country so that any countries with special characters for letters can be searched for with a normal keyboard or copying and pasting
-        // the name with its respective special characters.
+        const displayName = c.display;
         return (displayName && selectedCountries.list.filter(d => d.display.match(displayName)).length === 0)
-            && (!filterStr || plainName.toLowerCase().indexOf(filterStr) !== -1 || displayName.toLowerCase().indexOf(filterStr) !== -1)
+            && (!filterStr || displayName.toLowerCase().indexOf(filterStr) !== -1)
     }).sort(sortDisplayName);
 }
 

--- a/src/page-sections/afg-debt/countries/index.jsx
+++ b/src/page-sections/afg-debt/countries/index.jsx
@@ -15,25 +15,18 @@ const spendingConfig = {
   chapter: 'debt',
   defaultCountries: [{
     display: 'United States',
-    plainName: 'United States',
   }, {
     display: 'Germany',
-    plainName: 'Germany',
   }, {
     display: 'United Kingdom',
-    plainName: 'United Kingdom',
   }, {
     display: 'France',
-    plainName: 'France',
   }, {
     display: 'Australia',
-    plainName: 'Australia',
   }, {
     display: 'Italy',
-    plainName: 'Italy',
   }, {
     display: 'Turkey',
-    plainName: 'Turkey',
   }],
   accessibilityAttrs: {
     title: 'Federal Debt Country Comparison',

--- a/src/page-sections/afg-deficit/countries/index.jsx
+++ b/src/page-sections/afg-deficit/countries/index.jsx
@@ -22,25 +22,18 @@ const spendingConfig = {
   chapter: 'deficit',
   defaultCountries: [{
     display: 'United States',
-    plainName: 'United States',
   }, {
     display: 'Germany',
-    plainName: 'Germany',
   }, {
     display: 'United Kingdom',
-    plainName: 'United Kingdom',
   }, {
     display: 'France',
-    plainName: 'France',
   }, {
     display: 'Australia',
-    plainName: 'Australia',
   }, {
     display: 'Korea',
-    plainName: 'Korea',
   }, {
     display: 'Canada',
-    plainName: 'Canada',
   }]
 };
 

--- a/src/page-sections/afg-revenue/countries/index.jsx
+++ b/src/page-sections/afg-revenue/countries/index.jsx
@@ -14,25 +14,18 @@ const revenueConfig = {
   primaryColor: colors.revenuePrimary,
   defaultCountries: [{
     display: 'United States',
-    plainName: 'United States',
   }, {
     display: 'Germany',
-    plainName: 'Germany',
   }, {
     display: 'United Kingdom',
-    plainName: 'United Kingdom',
   }, {
     display: 'France',
-    plainName: 'France',
   }, {
     display: 'Australia',
-    plainName: 'Australia',
   }, {
     display: 'Korea',
-    plainName: 'Korea',
   }, {
     display: 'Canada',
-    plainName: 'Canada',
   }],
   accessibilityAttrs: {
     title: 'Federal Revenue Country Comparison',

--- a/src/page-sections/afg-spending/countries/index.jsx
+++ b/src/page-sections/afg-spending/countries/index.jsx
@@ -16,25 +16,18 @@ const spendingConfig = {
   chapter: 'spending',
   defaultCountries: [{
     display: 'United States',
-    plainName: 'United States',
   }, {
     display: 'Germany',
-    plainName: 'Germany',
   }, {
     display: 'United Kingdom',
-    plainName: 'United Kingdom',
   }, {
     display: 'France',
-    plainName: 'France',
   }, {
     display: 'Australia',
-    plainName: 'Australia',
   }, {
     display: 'Korea',
-    plainName: 'Korea',
   }, {
     display: 'Canada',
-    plainName: 'Canada',
   }],
   accessibilityAttrs: {
     title: 'Federal Spending Country Comparison',


### PR DESCRIPTION
…so removed the plainName var because it's only purpose was when special characters were removed

https://federal-spending-transparency.atlassian.net/browse/DA-8518

