### PR TITLE
8412 removed underline from the API Documentation link in the Resourc…

### DIFF
--- a/src/page-sections/home/resources-row/resources-row.jsx
+++ b/src/page-sections/home/resources-row/resources-row.jsx
@@ -65,7 +65,7 @@ const ResourcesRow = () => {
                   />
                 </div>
                 <div className={resourcesRowStyles.titleContainer}>
-                  <h1 className={`${resourcesRowStyles.title} ${resourcesRowStyles.titleAPI}`}>
+                  <h1 className={resourcesRowStyles.titleAPI}>
                     {resource.title}
                   </h1>
                   <p className={resourcesRowStyles.description}>

--- a/src/page-sections/home/resources-row/resources-row.module.scss
+++ b/src/page-sections/home/resources-row/resources-row.module.scss
@@ -41,7 +41,11 @@
     }
 
     .titleAPI {
-	color: #4a4a4a;
+	font-size: 1.125rem; // 18px
+	text-align: center;
+	color: #555555;
+	font-weight: 600;
+	margin-top: 31px;
     }
 
     h1 {
@@ -101,10 +105,6 @@
 	    text-decoration: underline;
 	}
     }
-
-
-
-
 }
 
 @media (max-width: $desktop - 1) {


### PR DESCRIPTION
…es section of the home page; changed its color to match the zeplin

https://federal-spending-transparency.atlassian.net/browse/DA-8412

