### PR TITLE
8373 - removed titleTemplate from SEO component because it was adding…

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -33,7 +33,6 @@ function SEO({ description, lang, meta, keywords, title }) {
         lang,
       }}
       title={title}
-      titleTemplate={`%s | ${site.siteMetadata.title}`}
       meta={[
         {
           name: `description`,
@@ -68,14 +67,6 @@ function SEO({ description, lang, meta, keywords, title }) {
           content: metaDescription,
         },
       ]
-        .concat(
-          keywords.length > 0
-            ? {
-                name: `keywords`,
-                content: keywords.join(`, `),
-              }
-            : []
-        )
         .concat(meta)}
     />
   )


### PR DESCRIPTION
… ' | Data Lab' to the end of the titles; also removed a block of code that concat-ed the keywords, because we're no longer using those

this was based on feedback from Allie, she saw the unneeded text in the titles and alerted me

https://federal-spending-transparency.atlassian.net/browse/DA-8373

