### PR TITLE
8601 - changed mobile copy for covid feature tile

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -45,7 +45,6 @@ To aid the nation’s recovery from the COVID-19 pandemic, the U.S. Congress pas
 							<>
 								<p>
 									Follow along as Data Lab tracks the flow of four emergency funding laws for COVID-19.
-									As of October 1, 2020, government agencies have reported $1.6 trillion in spending.
 								</p>
 							</>,
 						]}


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-8601

The sentence with the typo was removed from the MAC, so I updated this branch.