### PR TITLE
8458 update rd copy

### DIFF
--- a/src/page-sections/rd-in-contracting/categories/categories.jsx
+++ b/src/page-sections/rd-in-contracting/categories/categories.jsx
@@ -230,14 +230,16 @@ export default function Categories(props) {
 		return isOpen;
 	}
 
+	const altText = 'Horizontal scatter plot diagram displaying icons of various funding categories across the x-axis, ranging from approximately a net negative $200,000 for International Affairs to over 13 billion dollars for defense systems.';
+
 	function Chart() {
 		switch (device) {
 			case 'tablet':
-				return <Tablet />;
+				return <Tablet alt={altText} />;
 			case 'mobile':
-				return <Mobile />;
+				return <Mobile alt={altText} />;
 			default:
-				return <Desktop />;
+				return <Desktop alt={altText} />;
 		}
 	}
 
@@ -248,11 +250,12 @@ export default function Categories(props) {
 				<p>In this visualization, categories are represented by icons.</p>
 				<ul>
 					<li>
-						Click or tap on an icon to see the category name, total dollars contracted
-						for this category, and the percentage this total accounts for within R&D
-						contract spending
+						Click or tap on an icon to see the category name, total dollars
+						obligated for R&D in this category, total dollars obligated for COVID-19
+						R&D in this category, and the percentage this total accounts for within
+						R&D contract funding.
 					</li>
-					<li>To exit the pop-up, click or tap the X</li>
+					<li>To exit the pop-up, reclick the icon or click on the X.</li>
 				</ul>
 			</AccordionList>
 
@@ -260,8 +263,8 @@ export default function Categories(props) {
 				<Share
 					siteUrl={props.location.origin}
 					pageUrl={`${props.location.pathname}#${props.sectionId}`}
-					title="Data Lab - R&D in Contract Spending - U.S. Treasury"
-					text="What do agriculture, energy, and national defense all have in common? They’re all areas where the government spent dollars on R&D in 2019! Check out the latest analysis at #DataLab to learn more! #Transparency #Research"
+					title="Data Lab - R&D in Contract Funding - U.S. Treasury"
+					text="What do agriculture, energy, and national defense all have in common? They’re all areas where the government spent dollars on R&D in 2020! Check out the latest analysis at #DataLab to learn more! #Transparency #Research"
 					hoverColor="#1302d9"
 				/>
 			</ControlBar>
@@ -270,7 +273,7 @@ export default function Categories(props) {
 
 			<Downloads
 				href="/unstructured-data/rd-in-contracting/r&d_spending_by_category_fy2019_created_20200318.csv"
-				date="October 2019"
+				date="October 2020"
 			/>
 
 			{Object.keys(tooltipData).map(i => {

--- a/src/page-sections/rd-in-contracting/spending/spending-chart.jsx
+++ b/src/page-sections/rd-in-contracting/spending/spending-chart.jsx
@@ -204,7 +204,7 @@ export default class SpendingChart extends React.Component {
 							siteUrl={this.props.location.origin}
 							pageUrl={this.props.location.pathname + '#' + this.props.sectionId}
 							title='Data Lab - R&D in Contract Spending - U.S. Treasury'
-							text={`Which agencies had the highest proportion of contract spend devoted to R&D initiatives in FY20? Find out in #DataLab's newest analysis, R&D in Contract Spending! #OpenData #RandD`}
+							text={`Which agencies had the highest proportion of contract funding devoted to R&D initiatives in FY20? Find out in #DataLab's newest analysis, R&D in Contract Spending! #OpenData #RandD`}
 							hoverColor='#1302d9'
 						/>
 					</ControlBar>

--- a/src/page-sections/rd-in-contracting/spending/spending-chart.jsx
+++ b/src/page-sections/rd-in-contracting/spending/spending-chart.jsx
@@ -143,10 +143,9 @@ export default class SpendingChart extends React.Component {
 		<AccordionList title="Instructions">
 			<ul>
 				<li>
-					To better view the values for DHS, AID, DoEd, DOC, and the VA, click or tap
-					on the values for any of these agencies
+					Toggle between the views to see agency funding by total R&D contracts
+					and COVID-19 R&D contracts.
 				</li>
-				<li>To exit the pop-up, click or tap the X</li>
 			</ul>
 			<span className={styles.instructionHeader}>Label Definitions</span>
 			<div className={styles.instructionNotes}>
@@ -156,14 +155,13 @@ export default class SpendingChart extends React.Component {
         DOE – Department of Energy
         DOT – Department of Transportation
         DHS – Department of Homeland Security
-        AID – Agency for International Development
+        USAID – US Agency for International Development
         DoEd – Department of Education
         DOC – Department of Commerce
         VA – Department of Veterans’ Affairs`}
 			</div>
 		</AccordionList>
 	);
-
 
 	render() {
 		const {bWidth} = this.state;
@@ -194,6 +192,8 @@ export default class SpendingChart extends React.Component {
 
 		const desktopPopupStyle = {};
 
+		const altText = 'Donut chart of FY 20 federal agency R&D contract funding as a percentage of total contract funding by each agency. Below it is a bar chart of FY 20 federal agency R&D contract funding in billions by each agency. DoD & NASA have the highest R&D contract funding, with NASA having the highest R&D contract funding as proportion of total contract funding. Toggling to the COVID-19 R&D Contracts reveals a similar donut chart of FY 20 federal agency COVID-19 R&D Contracts as a percentage of total R&D contract funding. Below this chart is a bar chart of FY 20 federal agency COVID-19 R&D contracts in billions. HHS and DOD have the highest COVID-19 R&D contract funding, with HHS having the highest COVID-19 R&D contract funding as a proportion of total R&D contract funding. '
+
 		return (
 			<>
 				<h2 className='rd-viztitle'>{this.props.section.viztitle}</h2>
@@ -204,7 +204,7 @@ export default class SpendingChart extends React.Component {
 							siteUrl={this.props.location.origin}
 							pageUrl={this.props.location.pathname + '#' + this.props.sectionId}
 							title='Data Lab - R&D in Contract Spending - U.S. Treasury'
-							text={`Which agencies had the highest proportion of contract spend devoted to R&D initiatives in FY19? Find out in #DataLab's newest analysis, R&D in Contract Spending! #OpenData #RandD`}
+							text={`Which agencies had the highest proportion of contract spend devoted to R&D initiatives in FY20? Find out in #DataLab's newest analysis, R&D in Contract Spending! #OpenData #RandD`}
 							hoverColor='#1302d9'
 						/>
 					</ControlBar>
@@ -216,40 +216,60 @@ export default class SpendingChart extends React.Component {
 					/>
 					{isMobileSvg && (
 						<>
-						<div className={`${this.state.showDetails ? styles.svgPopoutShowMobile : styles.svgPopout}`}>
-							<CloseIcon className={styles.closeIconMobile} onClick={this.closePopup}/>
-							<SectionOneChartPopupMobile/>
-						</div>
-							{this.state.checked ? <span style={{color: 'red', fontSize: '50px', marginBottom: '30px'}}>cat photo here</span> : <SectionOneChartMobile />}
+							<div
+								className={`${this.state.showDetails ? styles.svgPopoutShowMobile : styles.svgPopout}`}>
+								<CloseIcon className={styles.closeIconMobile}
+													 onClick={this.closePopup}/>
+								<SectionOneChartPopupMobile/>
+							</div>
+							{this.state.checked
+								?
+								<span
+									style={{color: 'red', fontSize: '50px', marginBottom: '30px'}}>cat photo here</span>
+								:
+								<SectionOneChartMobile alt={altText}/>}
 						</>
-						)}
+					)}
 					{isTabletSvg && (
 						<>
-						<div className={`${this.state.showDetails ? styles.svgPopoutShow : styles.svgPopout}`}
-								 style={tabletPopupStyle}>
-							<SectionOneChartPopupTablet/>
-							<CloseIcon className={styles.closeIconTablet} onClick={this.closePopup}/>
-						</div>
-							{this.state.checked ? <span style={{color: 'red', fontSize: '50px', marginBottom: '30px'}}>cat photo here</span> : <SectionOneChartTablet />}
+							<div
+								className={`${this.state.showDetails ? styles.svgPopoutShow : styles.svgPopout}`}
+								style={tabletPopupStyle}>
+								<SectionOneChartPopupTablet/>
+								<CloseIcon className={styles.closeIconTablet}
+													 onClick={this.closePopup}/>
+							</div>
+							{this.state.checked
+								?
+								<span
+									style={{color: 'red', fontSize: '50px', marginBottom: '30px'}}>cat photo here</span>
+								:
+								<SectionOneChartTablet alt={altText}/>}
 						</>
-						)}
+					)}
 					{largestSvg && (
 						<>
-						<div className={`${this.state.showDetails ? styles.svgPopoutShow : styles.svgPopout}`}
-								 style={desktopPopupStyle}>
-							<SectionOneChartPopupDesktop/>
-							<CloseIcon className={styles.closeIconDesktop} onClick={this.closePopup}/>
-						</div>
-							{this.state.checked ? <span style={{color: 'red', fontSize: '50px', marginBottom: '30px'}}>cat photo here</span> : <SectionOneChartDesktop />}
+							<div
+								className={`${this.state.showDetails ? styles.svgPopoutShow : styles.svgPopout}`}
+								style={desktopPopupStyle}>
+								<SectionOneChartPopupDesktop/>
+								<CloseIcon className={styles.closeIconDesktop}
+													 onClick={this.closePopup}/>
+							</div>
+							{this.state.checked
+								?
+								<span style={{color: 'red', fontSize: '50px', marginBottom: '30px'}}>cat photo here</span>
+								:
+								<SectionOneChartDesktop alt={altText}/>}
 						</>
-						)}
+					)}
 					<Legend/>
 					<Downloads
 						href={'/unstructured-data/rd-in-contracting/r&d_funding_by_agency_fy2019_created_20200316.csv'}
-						date={'October 2019'}
+						date={'October 2020'}
 					/>
 				</div>
 			</>
-		)
+		);
 	}
 }

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -165,9 +165,9 @@ export default class RdInContractingPage extends React.Component {
 					From medicine to autonomous vehicles, R&D investments lead to new products,
 					technology advancements, and improved quality of life.  And in Fiscal Year
 					2020, R&D has been foundational to addressing the COVID-19 pandemic, from
-					vaccine development, production, and management. To fund R&D work, federal
-					agencies can use grants, loans, and contracts. In this analysis we focus on
-					contracts.
+					vaccine development, production, and logistics management. To fund R&D work,
+					federal agencies can use grants, loans, and contracts. In this analysis we
+					focus on contracts.
 				</p>
 				<p key={'si2'}>
 					Each of the 24 Chief Financial Officers (CFO) Act agencies awarded contracts
@@ -184,6 +184,13 @@ export default class RdInContractingPage extends React.Component {
 				space or conducting field research, they use the General Services Administration’s
 				Product and Services Codes (PSC).  Using PSCs, we grouped R&D contract funding
 				into 20 funding categories.
+			</p>,
+			<p>
+				The federal government awards a variety of entities, educational institutions,
+				private companies,  when it comes to R&D contracts. Below, we highlight the
+				top 5 R&D contract awardees by each of the 20 categories explored in Section 2.
+				We also break out the top 5 COVID-19 R&D contract awardees by the categories
+				under which COVID-19.
 			</p>,
 			<>
 				<p>
@@ -245,47 +252,68 @@ export default class RdInContractingPage extends React.Component {
 				readMoreStyle: { color: globalStyles.rdBlue },
 			},
 			{
-				section: 'R&D Funding Categories',
+				section: 'R&D Spending Categories',
 				anchor: 'categories',
 				number: '02',
-				subtext: 'R&D Funding Categories',
-				subblurb: 'R&D Funding Categories',
+				subtext: 'R&D Spending Categories',
+				subblurb: 'R&D Spending Categories',
 				sectionTeaser: (
 					<>
 						20{' '}
 						<span className={styles.subtitleHighlight} key={'categories-teaser'}>
 							categories of R&D
 						</span>{' '}
-						contract funding in FY 2020
+						contract spending in FY 2020
 					</>
 				),
 				introBlurb: this.getSecBlurbs()[1],
-				viztitle: 'R&D Federal Funding in Contracting by Category',
+				viztitle: 'R&D Federal Spending in Contracting by Category',
 				tagName: 'categories',
 				readMoreOnMobile: true,
 				readMoreStyle: { color: globalStyles.rdBlue },
 			},
 			{
-				section: 'Studies',
-				anchor: 'studies',
+				section: 'Contracts',
+				anchor: 'contracts',
 				number: '03',
-				subtext: 'Studies',
-				subblurb: 'The Big Picture for R&D',
+				subtext: 'Contracts',
+				subblurb: 'Top R&D Contracts',
 				comingSoon: true,
 				sectionTeaser: (
 					<>
-						<span className={styles.subtitleHighlight} key={'studies-teaser'}>
-							Long-term trends
-						</span>{' '}
-						in federal R&D spending
+							<span className={styles.subtitleHighlight} key={'studies-teaser'}>
+								Top 5 R&D Contracts
+							</span>{' '}
+						by category in FY 2020
 					</>
 				),
 				introBlurb: this.getSecBlurbs()[2],
-				viztitle: 'Federal R&D Obligations 2009-2019',
-				tagName: 'studies',
+				viztitle: '',
+				tagName: 'contracts',
 				readMoreOnMobile: true,
 				readMoreStyle: { color: globalStyles.rdBlue },
 			},
+			// {
+			// 	section: 'Studies',
+			// 	anchor: 'studies',
+			// 	number: '04',
+			// 	subtext: 'Studies',
+			// 	subblurb: 'The Big Picture for R&D',
+			// 	comingSoon: true,
+			// 	sectionTeaser: (
+			// 		<>
+			// 			<span className={styles.subtitleHighlight} key={'studies-teaser'}>
+			// 				Long-term trends
+			// 			</span>{' '}
+			// 			in federal R&D spending
+			// 		</>
+			// 	),
+			// 	introBlurb: this.getSecBlurbs()[3],
+			// 	viztitle: 'Federal R&D Obligations 2010-2020',
+			// 	tagName: 'studies',
+			// 	readMoreOnMobile: true,
+			// 	readMoreStyle: { color: globalStyles.rdBlue },
+			// },
 		];
 
 	prerelease = () => {

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -176,12 +176,12 @@ export default class RdInContractingPage extends React.Component {
 			</p>
 		</>,
 		<p>
-			Federal R&D contract spending supports a wide range of objectives, including
+			Federal R&D contract funding supports a wide range of objectives, including
 			agriculture, education, energy, housing, and national defense. When the
-			government uses contracts to buy products and services, like leasing
-			laboratory space or conducting field research, they use the General Services
-			Administration’s Product and Services Codes (PSC). Using PSCs, we grouped R&D
-			contract spending into 20 spending categories.
+			government uses contracts to buy products and services, like leasing laboratory
+			space or conducting field research, they use the General Services Administration’s
+			Product and Services Codes (PSC).  Using PSCs, we grouped R&D contract funding
+			into 20 funding categories.
 		</p>,
 		<>
 			<p>
@@ -243,22 +243,22 @@ export default class RdInContractingPage extends React.Component {
 			readMoreStyle: { color: globalStyles.rdBlue },
 		},
 		{
-			section: 'Categories',
+			section: 'R&D Funding Categories',
 			anchor: 'categories',
 			number: '02',
-			subtext: 'Categories',
-			subblurb: 'R&D Spending Categories',
+			subtext: 'R&D Funding Categories',
+			subblurb: 'R&D Funding Categories',
 			sectionTeaser: (
 				<>
 					20{' '}
 					<span className={styles.subtitleHighlight} key={'categories-teaser'}>
 						categories of R&D
 					</span>{' '}
-					contract spending in FY 2019
+					contract funding in FY 2020
 				</>
 			),
 			introBlurb: this.secBlurbs[1],
-			viztitle: 'R&D Federal Spending in Contracting by Category',
+			viztitle: 'R&D Federal Funding in Contracting by Category',
 			tagName: 'categories',
 			readMoreOnMobile: true,
 			readMoreStyle: { color: globalStyles.rdBlue },

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -152,139 +152,142 @@ export default class RdInContractingPage extends React.Component {
 		studies: Studies,
 	};
 
-	secBlurbs = [
-		<>
-			<p key={'si1'}>
-				Investment in Research and Development, or R&D, is largely seen as a driver
-				of innovation in both the public and private sectors.
-				<a href="#fn1" className="footnoteref">
-					<FootnoteAnchor footnoteId={'fr1'}/>
-					1
-				</a>{' '}
-				From medicine to autonomous vehicles, R&D investments lead to new products,
-				technology advancements, and improved quality of life.  And in Fiscal Year
-				2020, R&D has been foundational to addressing the COVID-19 pandemic, from
-				vaccine development, production, and management. To fund R&D work, federal
-				agencies can use grants, loans, and contracts. In this analysis we focus on
-				contracts.
-			</p>
-			<p key={'si2'}>
-				Each of the 24 Chief Financial Officers (CFO) Act agencies awarded contracts
-				to perform R&D work in fiscal year 2020 (FY 2020), totaling $47.8 billion.
-				Let’s take a look at the top ten CFO Act agencies by R&D contract funding
-				and the top seven agencies by COVID-19 R&D contract funding.
-			</p>
-		</>,
-		<p>
-			Federal R&D contract funding supports a wide range of objectives, including
-			agriculture, education, energy, housing, and national defense. When the
-			government uses contracts to buy products and services, like leasing laboratory
-			space or conducting field research, they use the General Services Administration’s
-			Product and Services Codes (PSC).  Using PSCs, we grouped R&D contract funding
-			into 20 funding categories.
-		</p>,
-		<>
+	getSecBlurbs = (state) =>
+		[
+			<>
+				<p key={'si1'}>
+					Investment in Research and Development, or R&D, is largely seen as a driver
+					of innovation in both the public and private sectors.
+					<a href="#fn1" className="footnoteref">
+						<FootnoteAnchor footnoteId={'fr1'}/>
+						1
+					</a>{' '}
+					From medicine to autonomous vehicles, R&D investments lead to new products,
+					technology advancements, and improved quality of life.  And in Fiscal Year
+					2020, R&D has been foundational to addressing the COVID-19 pandemic, from
+					vaccine development, production, and management. To fund R&D work, federal
+					agencies can use grants, loans, and contracts. In this analysis we focus on
+					contracts.
+				</p>
+				<p key={'si2'}>
+					Each of the 24 Chief Financial Officers (CFO) Act agencies awarded contracts
+					to perform R&D work in fiscal year 2020 (FY 2020), totaling $47.8 billion.
+					Let’s take a look at the top ten CFO Act agencies by R&D contract funding
+					and the top {state && state.screenMode > 1 ? 'seven' : 'five'} agencies by
+					COVID-19 R&D contract funding.
+				</p>
+			</>,
 			<p>
-				The federal government is one of the largest and most consistent funding
-				sources of R&D in the United States,
-				<a href="#fn2" className="footnoteref">
-					<FootnoteAnchor footnoteId={'fr2'}/>
-					2
-				</a>{' '}
-				where total R&D obligations had only a net 1% change over the last decade.
-				In total, the National Science Foundation reports that the federal
-				government obligated $146B to R&D initiatives in its 2019 budget, which
-				includes contracts as well as other key funding sources such as grants.
-				<a href="#fn3" className="footnoteref">
-					<FootnoteAnchor footnoteId={'fr3'}/>
-					3
-				</a>
-			</p>
-			<p>
-				<span className={styles.bold}>Why does the government invest in R&D?</span>
-				<br />A common rationale for federal R&D spending is that many socially
-				beneficial research projects would not be attempted if society depended on
-				the private sector alone for funding.
-				<a href="#fn4" className="footnoteref">
-					<FootnoteAnchor footnoteId={'fr4'}/>
-					4
-				</a>
-			</p>
-		</>,
-	];
+				Federal R&D contract funding supports a wide range of objectives, including
+				agriculture, education, energy, housing, and national defense. When the
+				government uses contracts to buy products and services, like leasing laboratory
+				space or conducting field research, they use the General Services Administration’s
+				Product and Services Codes (PSC).  Using PSCs, we grouped R&D contract funding
+				into 20 funding categories.
+			</p>,
+			<>
+				<p>
+					The federal government is one of the largest and most consistent funding
+					sources of R&D in the United States,
+					<a href="#fn2" className="footnoteref">
+						<FootnoteAnchor footnoteId={'fr2'}/>
+						2
+					</a>{' '}
+					where total R&D obligations had only a net 1% change over the last decade.
+					In total, the National Science Foundation reports that the federal
+					government obligated $146B to R&D initiatives in its 2019 budget, which
+					includes contracts as well as other key funding sources such as grants.
+					<a href="#fn3" className="footnoteref">
+						<FootnoteAnchor footnoteId={'fr3'}/>
+						3
+					</a>
+				</p>
+				<p>
+					<span className={styles.bold}>Why does the government invest in R&D?</span>
+					<br />A common rationale for federal R&D spending is that many socially
+					beneficial research projects would not be attempted if society depended on
+					the private sector alone for funding.
+					<a href="#fn4" className="footnoteref">
+						<FootnoteAnchor footnoteId={'fr4'}/>
+						4
+					</a>
+				</p>
+			</>,
+		];
 
-	sections = [
-		{
-			section: 'Funding',
-			anchor: 'spending',
-			number: '01',
-			subtext: 'Funding',
-			subblurb: '2020 Agency R&D Funding',
-			sectionTeaser: (
-				<>
-					What{' '}
-					<span className={styles.subtitleHighlight}>
-						portion of federal agency contract funding in FY 2020
-					</span>{' '}
-					goes to R&D initiatives?
-				</>
-			),
-			introBlurb: this.secBlurbs[0],
-			accordion: (
-				<aside>
-					<Accordion title="What is R&D?" color="#1302D9" backgroundColor="#E7E5FB">
-						{this.whatIsContents()}
-					</Accordion>
-				</aside>
-			),
-			viztitle: 'R&D as a Portion of Total Federal Contract Funding by Agency',
-			tagName: 'spending',
-			readMoreOnMobile: true,
-			readMoreStyle: { color: globalStyles.rdBlue },
-		},
-		{
-			section: 'R&D Funding Categories',
-			anchor: 'categories',
-			number: '02',
-			subtext: 'R&D Funding Categories',
-			subblurb: 'R&D Funding Categories',
-			sectionTeaser: (
-				<>
-					20{' '}
-					<span className={styles.subtitleHighlight} key={'categories-teaser'}>
-						categories of R&D
-					</span>{' '}
-					contract funding in FY 2020
-				</>
-			),
-			introBlurb: this.secBlurbs[1],
-			viztitle: 'R&D Federal Funding in Contracting by Category',
-			tagName: 'categories',
-			readMoreOnMobile: true,
-			readMoreStyle: { color: globalStyles.rdBlue },
-		},
-		{
-			section: 'Studies',
-			anchor: 'studies',
-			number: '03',
-			subtext: 'Studies',
-			subblurb: 'The Big Picture for R&D',
-			comingSoon: true,
-			sectionTeaser: (
-				<>
-					<span className={styles.subtitleHighlight} key={'studies-teaser'}>
-						Long-term trends
-					</span>{' '}
-					in federal R&D spending
-				</>
-			),
-			introBlurb: this.secBlurbs[2],
-			viztitle: 'Federal R&D Obligations 2009-2019',
-			tagName: 'studies',
-			readMoreOnMobile: true,
-			readMoreStyle: { color: globalStyles.rdBlue },
-		},
-	];
+	getSections = (state) =>
+		[
+			{
+				section: 'Funding',
+				anchor: 'spending',
+				number: '01',
+				subtext: 'Funding',
+				subblurb: '2020 Agency R&D Funding',
+				sectionTeaser: (
+					<>
+						What{' '}
+						<span className={styles.subtitleHighlight}>
+							portion of federal agency contract funding in FY 2020
+						</span>{' '}
+						goes to R&D initiatives?
+					</>
+				),
+				introBlurb: this.getSecBlurbs(state)[0],
+				accordion: (
+					<aside>
+						<Accordion title="What is R&D?" color="#1302D9" backgroundColor="#E7E5FB">
+							{this.whatIsContents()}
+						</Accordion>
+					</aside>
+				),
+				viztitle: 'R&D as a Portion of Total Federal Contract Funding by Agency',
+				tagName: 'spending',
+				readMoreOnMobile: true,
+				readMoreStyle: { color: globalStyles.rdBlue },
+			},
+			{
+				section: 'R&D Funding Categories',
+				anchor: 'categories',
+				number: '02',
+				subtext: 'R&D Funding Categories',
+				subblurb: 'R&D Funding Categories',
+				sectionTeaser: (
+					<>
+						20{' '}
+						<span className={styles.subtitleHighlight} key={'categories-teaser'}>
+							categories of R&D
+						</span>{' '}
+						contract funding in FY 2020
+					</>
+				),
+				introBlurb: this.getSecBlurbs()[1],
+				viztitle: 'R&D Federal Funding in Contracting by Category',
+				tagName: 'categories',
+				readMoreOnMobile: true,
+				readMoreStyle: { color: globalStyles.rdBlue },
+			},
+			{
+				section: 'Studies',
+				anchor: 'studies',
+				number: '03',
+				subtext: 'Studies',
+				subblurb: 'The Big Picture for R&D',
+				comingSoon: true,
+				sectionTeaser: (
+					<>
+						<span className={styles.subtitleHighlight} key={'studies-teaser'}>
+							Long-term trends
+						</span>{' '}
+						in federal R&D spending
+					</>
+				),
+				introBlurb: this.getSecBlurbs()[2],
+				viztitle: 'Federal R&D Obligations 2009-2019',
+				tagName: 'studies',
+				readMoreOnMobile: true,
+				readMoreStyle: { color: globalStyles.rdBlue },
+			},
+		];
 
 	prerelease = () => {
 		if (!this.state.isQAT) {
@@ -309,14 +312,14 @@ export default class RdInContractingPage extends React.Component {
 					hwctaLink={this.props.location.pathname + '/methodologies'}
 					title="Research & Development in Contract Funding"
 					introSentence="How much did the federal government invest in Research & Development with FY 2020 Contract Funding?"
-					sectionToc={this.sections}
+					sectionToc={this.getSections()}
 					hwctaLink={this.props.location.pathname + '/methodologies'}>
 					<SEO
 						description="How much does the federal government invest in Research & Development? In FY 2020, $47.8 billion was contracted to R&D initiatives."
 						title="Research & Development in Contract Funding | U.S. Treasury Data Lab"
 					/>
 
-					{this.sections.map((item, key) => {
+					{this.getSections(this.state).map((item, key) => {
 						const SectionTag = this.sectionComponents[item.tagName];
 						if (!item.comingSoon) {
 							return (

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -345,53 +345,7 @@ export default class RdInContractingPage extends React.Component {
 											https://www.nsf.gov/statistics/2018/nsb20181/digest/sections/global-r-d-one-measure-of-commitment-to-innovation
 											<LaunchOutlinedIcon className={styles.extLink} />
 										</a>
-									</>,
-									<>
-										<FootnoteAnchor footnoteId={"fn2"}/>
-										Sargent, John F. "Federal Research and Development (R&D) Funding:
-										FY2019." Federal Research and Development (R&D) Funding: FY2019,
-										October 4, 2018.
-										<br />
-										<a
-											href="https://fas.org/sgp/crs/misc/R45150.pdf"
-											rel="noreferrer noopener"
-											target="_blank"
-											className={styles.link}>
-											https://fas.org/sgp/crs/misc/R45150.pdf
-											<LaunchOutlinedIcon className={styles.extLink} />
-										</a>
-									</>,
-									<>
-										<FootnoteAnchor footnoteId={"fn3"}/>
-										National Center for Science and Engineering Statistics, National
-										Science Foundation. 2019. Federal R&D Funding, by Budget Function:
-										Fiscal Years 2018–20. Detailed Statistical Tables NSF 20-305.
-										Alexandria, VA. Available at{' '}
-										<a
-											href="https://ncses.nsf.gov/pubs/nsf20305/"
-											rel="noreferrer noopener"
-											target="_blank"
-											className={styles.link}>
-											https://ncses.nsf.gov/pubs/nsf20305/
-											<LaunchOutlinedIcon className={styles.extLink} />
-										</a>
-										.
-									</>,
-									<>
-										<FootnoteAnchor footnoteId={"fn4"}/>
-										Maloney, Carolyn B, and Charles E Schumer. “The Pivotal Role of
-										Government Investment in Basic Research.” U.S. Congress Joint Economic
-										Committee. U.S. Congress Joint Economic Committee, May 2010.
-										<br />
-										<a
-											href="https://www.jec.senate.gov/public/_cache/files/29aac456-fce3-4d69-956f-4add06f111c1/rd-report--final-report.pdf"
-											rel="noreferrer noopener"
-											target="_blank"
-											className={styles.link}>
-											https://www.jec.senate.gov/public/_cache/files/29aac456-fce3-4d69-956f-4add06f111c1/rd-report--final-report.pdf
-											<LaunchOutlinedIcon className={styles.extLink} />
-										</a>
-									</>,
+									</>
 								]}
 							/>
 						</Grid>

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -152,7 +152,7 @@ export default class RdInContractingPage extends React.Component {
 		studies: Studies,
 	};
 
-	getSecBlurbs = (state) =>
+	getSecBlurbs = ()  =>
 		[
 			<>
 				<p key={'si1'}>
@@ -173,8 +173,8 @@ export default class RdInContractingPage extends React.Component {
 					Each of the 24 Chief Financial Officers (CFO) Act agencies awarded contracts
 					to perform R&D work in fiscal year 2020 (FY 2020), totaling $47.8 billion.
 					Let’s take a look at the top ten CFO Act agencies by R&D contract funding
-					and the top {state && state.screenMode > 1 ? 'seven' : 'five'} agencies by
-					COVID-19 R&D contract funding.
+					and the top {this.state && this.state.screenMode > 1 ? 'seven' : 'five'}{' '}
+					agencies by COVID-19 R&D contract funding.
 				</p>
 			</>,
 			<p>
@@ -215,8 +215,7 @@ export default class RdInContractingPage extends React.Component {
 			</>,
 		];
 
-	getSections = (state) =>
-		[
+	getSections = () => [
 			{
 				section: 'Funding',
 				anchor: 'spending',
@@ -232,7 +231,7 @@ export default class RdInContractingPage extends React.Component {
 						goes to R&D initiatives?
 					</>
 				),
-				introBlurb: this.getSecBlurbs(state)[0],
+				introBlurb: this.getSecBlurbs()[0],
 				accordion: (
 					<aside>
 						<Accordion title="What is R&D?" color="#1302D9" backgroundColor="#E7E5FB">
@@ -312,14 +311,14 @@ export default class RdInContractingPage extends React.Component {
 					hwctaLink={this.props.location.pathname + '/methodologies'}
 					title="Research & Development in Contract Funding"
 					introSentence="How much did the federal government invest in Research & Development with FY 2020 Contract Funding?"
-					sectionToc={this.getSections()}
+					sectionToc={this.sections}
 					hwctaLink={this.props.location.pathname + '/methodologies'}>
 					<SEO
 						description="How much does the federal government invest in Research & Development? In FY 2020, $47.8 billion was contracted to R&D initiatives."
 						title="Research & Development in Contract Funding | U.S. Treasury Data Lab"
 					/>
 
-					{this.getSections(this.state).map((item, key) => {
+					{this.getSections().map((item, key) => {
 						const SectionTag = this.sectionComponents[item.tagName];
 						if (!item.comingSoon) {
 							return (

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -25,7 +25,7 @@ import Tablet from 'src/svgs/rd-and-contracting/comingsoon/tablet.svg';
 import Mobile from 'src/svgs/rd-and-contracting/comingsoon/mobile.svg';
 import { ScreenModeEnum, checkScreenMode } from 'src/utils/screen-mode.js';
 import { HeadOnly } from 'src/components/headers/headers';
-import FootnoteAnchor from "../../components/footnotes/footnote-anchor";
+import FootnoteAnchor from '../../components/footnotes/footnote-anchor';
 
 export default class RdInContractingPage extends React.Component {
 	constructor(props) {
@@ -152,169 +152,164 @@ export default class RdInContractingPage extends React.Component {
 		studies: Studies,
 	};
 
-	getSecBlurbs = ()  =>
-		[
-			<>
-				<p key={'si1'}>
-					Investment in Research and Development, or R&D, is largely seen as a driver
-					of innovation in both the public and private sectors.
-					<a href="#fn1" className="footnoteref">
-						<FootnoteAnchor footnoteId={'fr1'}/>
-						1
-					</a>{' '}
-					From medicine to autonomous vehicles, R&D investments lead to new products,
-					technology advancements, and improved quality of life.  And in Fiscal Year
-					2020, R&D has been foundational to addressing the COVID-19 pandemic, from
-					vaccine development, production, and logistics management. To fund R&D work,
-					federal agencies can use grants, loans, and contracts. In this analysis we
-					focus on contracts.
-				</p>
-				<p key={'si2'}>
-					Each of the 24 Chief Financial Officers (CFO) Act agencies awarded contracts
-					to perform R&D work in fiscal year 2020 (FY 2020), totaling $47.8 billion.
-					Let’s take a look at the top ten CFO Act agencies by R&D contract funding
-					and the top {this.state && this.state.screenMode > 1 ? 'seven' : 'five'}{' '}
-					agencies by COVID-19 R&D contract funding.
-				</p>
-			</>,
+	getSecBlurbs = () => [
+		<>
+			<p key={'si1'}>
+				Investment in Research and Development, or R&D, is largely seen as a driver
+				of innovation in both the public and private sectors.
+				<a href="#fn1" className="footnoteref">
+					<FootnoteAnchor footnoteId={'fr1'} />1
+				</a>{' '}
+				From medicine to autonomous vehicles, R&D investments lead to new products,
+				technology advancements, and improved quality of life. And in Fiscal Year
+				2020, R&D has been foundational to addressing the COVID-19 pandemic, from
+				vaccine development, production, and logistics management. To fund R&D work,
+				federal agencies can use grants, loans, and contracts. In this analysis we
+				focus on contracts.
+			</p>
+			<p key={'si2'}>
+				Each of the 24 Chief Financial Officers (CFO) Act agencies awarded contracts
+				to perform R&D work in fiscal year 2020 (FY 2020), totaling $47.8 billion.
+				Let’s take a look at the top ten CFO Act agencies by R&D contract funding
+				and the top {this.state && this.state.screenMode > 1 ? 'seven' : 'five'}{' '}
+				agencies by COVID-19 R&D contract funding.
+			</p>
+		</>,
+		<p>
+			Federal R&D contract funding supports a wide range of objectives, including
+			agriculture, education, energy, housing, and national defense. When the
+			government uses contracts to buy products and services, like leasing
+			laboratory space or conducting field research, they use the General Services
+			Administration’s Product and Services Codes (PSC). Using PSCs, we grouped R&D
+			contract funding into 20 funding categories.
+		</p>,
+		<p>
+			The federal government awards a variety of entities, educational
+			institutions, private companies, when it comes to R&D contracts. Below, we
+			highlight the top 5 R&D contract awardees by each of the 20 categories
+			explored in Section 2. We also break out the top 5 COVID-19 R&D contract
+			awardees by the categories under which COVID-19.
+		</p>,
+		<>
 			<p>
-				Federal R&D contract funding supports a wide range of objectives, including
-				agriculture, education, energy, housing, and national defense. When the
-				government uses contracts to buy products and services, like leasing laboratory
-				space or conducting field research, they use the General Services Administration’s
-				Product and Services Codes (PSC).  Using PSCs, we grouped R&D contract funding
-				into 20 funding categories.
-			</p>,
+				The federal government is one of the largest and most consistent funding
+				sources of R&D in the United States,
+				<a href="#fn2" className="footnoteref">
+					<FootnoteAnchor footnoteId={'fr2'} />2
+				</a>{' '}
+				where total R&D obligations had only a net 1% change over the last decade.
+				In total, the National Science Foundation reports that the federal
+				government obligated $146B to R&D initiatives in its 2019 budget, which
+				includes contracts as well as other key funding sources such as grants.
+				<a href="#fn3" className="footnoteref">
+					<FootnoteAnchor footnoteId={'fr3'} />3
+				</a>
+			</p>
 			<p>
-				The federal government awards a variety of entities, educational institutions,
-				private companies,  when it comes to R&D contracts. Below, we highlight the
-				top 5 R&D contract awardees by each of the 20 categories explored in Section 2.
-				We also break out the top 5 COVID-19 R&D contract awardees by the categories
-				under which COVID-19.
-			</p>,
-			<>
-				<p>
-					The federal government is one of the largest and most consistent funding
-					sources of R&D in the United States,
-					<a href="#fn2" className="footnoteref">
-						<FootnoteAnchor footnoteId={'fr2'}/>
-						2
-					</a>{' '}
-					where total R&D obligations had only a net 1% change over the last decade.
-					In total, the National Science Foundation reports that the federal
-					government obligated $146B to R&D initiatives in its 2019 budget, which
-					includes contracts as well as other key funding sources such as grants.
-					<a href="#fn3" className="footnoteref">
-						<FootnoteAnchor footnoteId={'fr3'}/>
-						3
-					</a>
-				</p>
-				<p>
-					<span className={styles.bold}>Why does the government invest in R&D?</span>
-					<br />A common rationale for federal R&D spending is that many socially
-					beneficial research projects would not be attempted if society depended on
-					the private sector alone for funding.
-					<a href="#fn4" className="footnoteref">
-						<FootnoteAnchor footnoteId={'fr4'}/>
-						4
-					</a>
-				</p>
-			</>,
-		];
+				<span className={styles.bold}>Why does the government invest in R&D?</span>
+				<br />A common rationale for federal R&D spending is that many socially
+				beneficial research projects would not be attempted if society depended on
+				the private sector alone for funding.
+				<a href="#fn4" className="footnoteref">
+					<FootnoteAnchor footnoteId={'fr4'} />4
+				</a>
+			</p>
+		</>,
+	];
 
-	getSections = () => [
-			{
-				section: 'Funding',
-				anchor: 'spending',
-				number: '01',
-				subtext: 'Funding',
-				subblurb: '2020 Agency R&D Funding',
-				sectionTeaser: (
-					<>
-						What{' '}
-						<span className={styles.subtitleHighlight}>
-							portion of federal agency contract funding in FY 2020
-						</span>{' '}
-						goes to R&D initiatives?
-					</>
-				),
-				introBlurb: this.getSecBlurbs()[0],
-				accordion: (
-					<aside>
-						<Accordion title="What is R&D?" color="#1302D9" backgroundColor="#E7E5FB">
-							{this.whatIsContents()}
-						</Accordion>
-					</aside>
-				),
-				viztitle: 'R&D as a Portion of Total Federal Contract Funding by Agency',
-				tagName: 'spending',
-				readMoreOnMobile: true,
-				readMoreStyle: { color: globalStyles.rdBlue },
-			},
-			{
-				section: 'R&D Spending Categories',
-				anchor: 'categories',
-				number: '02',
-				subtext: 'R&D Spending Categories',
-				subblurb: 'R&D Spending Categories',
-				sectionTeaser: (
-					<>
-						20{' '}
-						<span className={styles.subtitleHighlight} key={'categories-teaser'}>
-							categories of R&D
-						</span>{' '}
-						contract spending in FY 2020
-					</>
-				),
-				introBlurb: this.getSecBlurbs()[1],
-				viztitle: 'R&D Federal Spending in Contracting by Category',
-				tagName: 'categories',
-				readMoreOnMobile: true,
-				readMoreStyle: { color: globalStyles.rdBlue },
-			},
-			// {
-			// 	section: 'Contracts',
-			// 	anchor: 'contracts',
-			// 	number: '03',
-			// 	subtext: 'Contracts',
-			// 	subblurb: 'Top R&D Contracts',
-			// 	comingSoon: true,
-			// 	sectionTeaser: (
-			// 		<>
-			// 				<span className={styles.subtitleHighlight} key={'studies-teaser'}>
-			// 					Top 5 R&D Contracts
-			// 				</span>{' '}
-			// 			by category in FY 2020
-			// 		</>
-			// 	),
-			// 	introBlurb: this.getSecBlurbs()[2],
-			// 	viztitle: '',
-			// 	tagName: 'contracts',
-			// 	readMoreOnMobile: true,
-			// 	readMoreStyle: { color: globalStyles.rdBlue },
-			// },
-			// {
-			// 	section: 'Studies',
-			// 	anchor: 'studies',
-			// 	number: '04',
-			// 	subtext: 'Studies',
-			// 	subblurb: 'The Big Picture for R&D',
-			// 	comingSoon: true,
-			// 	sectionTeaser: (
-			// 		<>
-			// 			<span className={styles.subtitleHighlight} key={'studies-teaser'}>
-			// 				Long-term trends
-			// 			</span>{' '}
-			// 			in federal R&D spending
-			// 		</>
-			// 	),
-			// 	introBlurb: this.getSecBlurbs()[3],
-			// 	viztitle: 'Federal R&D Obligations 2010-2020',
-			// 	tagName: 'studies',
-			// 	readMoreOnMobile: true,
-			// 	readMoreStyle: { color: globalStyles.rdBlue },
-			// },
-		];
+	sections = [
+		{
+			section: 'Funding',
+			anchor: 'spending',
+			number: '01',
+			subtext: 'Funding',
+			subblurb: '2020 Agency R&D Funding',
+			sectionTeaser: (
+				<>
+					What{' '}
+					<span className={styles.subtitleHighlight}>
+						portion of federal agency contract funding in FY 2020
+					</span>{' '}
+					goes to R&D initiatives?
+				</>
+			),
+			introBlurb: this.getSecBlurbs()[0],
+			accordion: (
+				<aside>
+					<Accordion title="What is R&D?" color="#1302D9" backgroundColor="#E7E5FB">
+						{this.whatIsContents()}
+					</Accordion>
+				</aside>
+			),
+			viztitle: 'R&D as a Portion of Total Federal Contract Funding by Agency',
+			tagName: 'spending',
+			readMoreOnMobile: true,
+			readMoreStyle: { color: globalStyles.rdBlue },
+		},
+		{
+			section: 'R&D Spending Categories',
+			anchor: 'categories',
+			number: '02',
+			subtext: 'R&D Spending Categories',
+			subblurb: 'R&D Spending Categories',
+			sectionTeaser: (
+				<>
+					20{' '}
+					<span className={styles.subtitleHighlight} key={'categories-teaser'}>
+						categories of R&D
+					</span>{' '}
+					contract spending in FY 2020
+				</>
+			),
+			introBlurb: this.getSecBlurbs()[1],
+			viztitle: 'R&D Federal Spending in Contracting by Category',
+			tagName: 'categories',
+			readMoreOnMobile: true,
+			readMoreStyle: { color: globalStyles.rdBlue },
+		},
+		// {
+		// 	section: 'Contracts',
+		// 	anchor: 'contracts',
+		// 	number: '03',
+		// 	subtext: 'Contracts',
+		// 	subblurb: 'Top R&D Contracts',
+		// 	comingSoon: true,
+		// 	sectionTeaser: (
+		// 		<>
+		// 				<span className={styles.subtitleHighlight} key={'studies-teaser'}>
+		// 					Top 5 R&D Contracts
+		// 				</span>{' '}
+		// 			by category in FY 2020
+		// 		</>
+		// 	),
+		// 	introBlurb: this.getSecBlurbs()[2],
+		// 	viztitle: '',
+		// 	tagName: 'contracts',
+		// 	readMoreOnMobile: true,
+		// 	readMoreStyle: { color: globalStyles.rdBlue },
+		// },
+		// {
+		// 	section: 'Studies',
+		// 	anchor: 'studies',
+		// 	number: '04',
+		// 	subtext: 'Studies',
+		// 	subblurb: 'The Big Picture for R&D',
+		// 	comingSoon: true,
+		// 	sectionTeaser: (
+		// 		<>
+		// 			<span className={styles.subtitleHighlight} key={'studies-teaser'}>
+		// 				Long-term trends
+		// 			</span>{' '}
+		// 			in federal R&D spending
+		// 		</>
+		// 	),
+		// 	introBlurb: this.getSecBlurbs()[3],
+		// 	viztitle: 'Federal R&D Obligations 2010-2020',
+		// 	tagName: 'studies',
+		// 	readMoreOnMobile: true,
+		// 	readMoreStyle: { color: globalStyles.rdBlue },
+		// },
+	];
 
 	prerelease = () => {
 		if (!this.state.isQAT) {
@@ -341,14 +336,13 @@ export default class RdInContractingPage extends React.Component {
 					introSentence="How much did the federal government invest in Research & Development with FY 2020 Contract Funding?"
 					sectionToc={this.sections}
 					hwctaLink={this.props.location.pathname + '/methodologies'}
-					scrollingToc
-				>
+					scrollingToc>
 					<SEO
 						description="How much does the federal government invest in Research & Development? In FY 2020, $47.8 billion was contracted to R&D initiatives."
 						title="Research & Development in Contract Funding | U.S. Treasury Data Lab"
 					/>
 
-					{this.getSections().map((item, key) => {
+					{this.sections.map((item, key) => {
 						const SectionTag = this.sectionComponents[item.tagName];
 						if (!item.comingSoon) {
 							return (
@@ -368,7 +362,7 @@ export default class RdInContractingPage extends React.Component {
 							<Footnotes
 								footnotes={[
 									<>
-										<FootnoteAnchor footnoteId={"fn1"}/>
+										<FootnoteAnchor footnoteId={'fn1'} />
 										Global R&D: One Measure of Commitment to Innovation, Global R&D: One
 										Measure of Commitment to Innovation § (2018).
 										<br />
@@ -380,7 +374,7 @@ export default class RdInContractingPage extends React.Component {
 											https://www.nsf.gov/statistics/2018/nsb20181/digest/sections/global-r-d-one-measure-of-commitment-to-innovation
 											<LaunchOutlinedIcon className={styles.extLink} />
 										</a>
-									</>
+									</>,
 								]}
 							/>
 						</Grid>

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -341,7 +341,8 @@ export default class RdInContractingPage extends React.Component {
 					introSentence="How much did the federal government invest in Research & Development with FY 2020 Contract Funding?"
 					sectionToc={this.sections}
 					hwctaLink={this.props.location.pathname + '/methodologies'}
-					scrollingToc>
+					scrollingToc
+				>
 					<SEO
 						description="How much does the federal government invest in Research & Development? In FY 2020, $47.8 billion was contracted to R&D initiatives."
 						title="Research & Development in Contract Funding | U.S. Treasury Data Lab"

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -162,14 +162,17 @@ export default class RdInContractingPage extends React.Component {
 					1
 				</a>{' '}
 				From medicine to autonomous vehicles, R&D investments lead to new products,
-				technology advancements, and improved quality of life. To fund R&D work,
-				federal agencies can use grants, loans, and contracts. In this analysis we
-				focus on contracts.
+				technology advancements, and improved quality of life.  And in Fiscal Year
+				2020, R&D has been foundational to addressing the COVID-19 pandemic, from
+				vaccine development, production, and management. To fund R&D work, federal
+				agencies can use grants, loans, and contracts. In this analysis we focus on
+				contracts.
 			</p>
 			<p key={'si2'}>
 				Each of the 24 Chief Financial Officers (CFO) Act agencies awarded contracts
-				to perform R&D work in fiscal year 2019 (FY 2019), totaling $41.5B. Let’s
-				take a look at the top ten CFO Act agencies by R&D contract spending.
+				to perform R&D work in fiscal year 2020 (FY 2020), totaling $47.8 billion.
+				Let’s take a look at the top ten CFO Act agencies by R&D contract funding
+				and the top seven agencies by COVID-19 R&D contract funding.
 			</p>
 		</>,
 		<p>
@@ -212,16 +215,16 @@ export default class RdInContractingPage extends React.Component {
 
 	sections = [
 		{
-			section: 'Spending',
+			section: 'Funding',
 			anchor: 'spending',
 			number: '01',
-			subtext: 'Spending',
-			subblurb: '2019 Agency Spending',
+			subtext: 'Funding',
+			subblurb: '2020 Agency R&D Funding',
 			sectionTeaser: (
 				<>
 					What{' '}
 					<span className={styles.subtitleHighlight}>
-						portion of federal agency contract spending
+						portion of federal agency contract funding in FY 2020
 					</span>{' '}
 					goes to R&D initiatives?
 				</>
@@ -234,7 +237,7 @@ export default class RdInContractingPage extends React.Component {
 					</Accordion>
 				</aside>
 			),
-			viztitle: 'R&D as a Portion of Total Federal Contract Spending by Agency',
+			viztitle: 'R&D as a Portion of Total Federal Contract Funding by Agency',
 			tagName: 'spending',
 			readMoreOnMobile: true,
 			readMoreStyle: { color: globalStyles.rdBlue },
@@ -304,8 +307,8 @@ export default class RdInContractingPage extends React.Component {
 			return (
 				<StoryLayout
 					hwctaLink={this.props.location.pathname + '/methodologies'}
-					title="Research & Development in Contract Spending"
-					introSentence="How much did the federal government invest in Research & Development with FY 2019 Contract Spending?"
+					title="Research & Development in Contract Funding"
+					introSentence="How much did the federal government invest in Research & Development with FY 2020 Contract Funding?"
 					sectionToc={this.sections}
 					hwctaLink={this.props.location.pathname + '/methodologies'}>
 					<SEO

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -272,27 +272,27 @@ export default class RdInContractingPage extends React.Component {
 				readMoreOnMobile: true,
 				readMoreStyle: { color: globalStyles.rdBlue },
 			},
-			{
-				section: 'Contracts',
-				anchor: 'contracts',
-				number: '03',
-				subtext: 'Contracts',
-				subblurb: 'Top R&D Contracts',
-				comingSoon: true,
-				sectionTeaser: (
-					<>
-							<span className={styles.subtitleHighlight} key={'studies-teaser'}>
-								Top 5 R&D Contracts
-							</span>{' '}
-						by category in FY 2020
-					</>
-				),
-				introBlurb: this.getSecBlurbs()[2],
-				viztitle: '',
-				tagName: 'contracts',
-				readMoreOnMobile: true,
-				readMoreStyle: { color: globalStyles.rdBlue },
-			},
+			// {
+			// 	section: 'Contracts',
+			// 	anchor: 'contracts',
+			// 	number: '03',
+			// 	subtext: 'Contracts',
+			// 	subblurb: 'Top R&D Contracts',
+			// 	comingSoon: true,
+			// 	sectionTeaser: (
+			// 		<>
+			// 				<span className={styles.subtitleHighlight} key={'studies-teaser'}>
+			// 					Top 5 R&D Contracts
+			// 				</span>{' '}
+			// 			by category in FY 2020
+			// 		</>
+			// 	),
+			// 	introBlurb: this.getSecBlurbs()[2],
+			// 	viztitle: '',
+			// 	tagName: 'contracts',
+			// 	readMoreOnMobile: true,
+			// 	readMoreStyle: { color: globalStyles.rdBlue },
+			// },
 			// {
 			// 	section: 'Studies',
 			// 	anchor: 'studies',

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -312,8 +312,8 @@ export default class RdInContractingPage extends React.Component {
 					sectionToc={this.sections}
 					hwctaLink={this.props.location.pathname + '/methodologies'}>
 					<SEO
-						description="How much does the federal government invest in Research & Development? In FY 2019, $41.5 billion was contracted to R&D initiatives."
-						title="U.S. Treasury Data Lab – Research & Development in Contract Spending"
+						description="How much does the federal government invest in Research & Development? In FY 2020, $47.8 billion was contracted to R&D initiatives."
+						title="Research & Development in Contract Funding | U.S. Treasury Data Lab"
 					/>
 
 					{this.sections.map((item, key) => {

--- a/src/pages/rd-in-contracting/methodologies.jsx
+++ b/src/pages/rd-in-contracting/methodologies.jsx
@@ -14,11 +14,11 @@ export default class RDHWCTA extends React.Component {
   title = 'Research & Development in Contract Spending';
   methodologies = [{
     content: <>
-      <p>We conducted this analysis using agency contract award data for Fiscal Year 2019, which agencies report to <a href='https://www.usaspending.gov/#/' rel='noreferrer noopener' target='_blank'>USAspending.gov</a>. Each reported contract includes information about the agency and sub-agency that awarded the contract, the amount obligated by the contract, and a Product and Service Code (PSC) that indicates the goods or services delivered as a result of the contract.</p>
+      <p>We conducted this analysis using agency contract award data for Fiscal Year 2020, which agencies report to <a href='https://www.usaspending.gov/#/' rel='noreferrer noopener' target='_blank'>USAspending.gov</a>. Each reported contract includes information about the agency and sub-agency that awarded the contract, the amount obligated by the contract, and a Product and Service Code (PSC) that indicates the goods or services delivered as a result of the contract.</p>
       <p>We excluded research and development (R&D) assistance funding such as grants, loans and scholarships in the first two sections of our analysis because, unlike PSCs, they are tracked using the Catalog of Federal Domestic Assistance (CFDA) codes. Since one CFDA listing can be used for a range of purposes, it is difficult to identify and verify funding devoted to R&D within a given CFDA.</p>
       <p>For the category analysis, we classified R&D awards using the <a href='https://www.acquisition.gov/PSC_Manual' rel='noreferrer noopener' target='_blank'>General Services Administration’s PSC Manual</a>. We excluded contract spending designated with PSC codes that ended in 5 and 7, which represent Operational System Development (5) and Commercialization (7), since these codes fall outside of the National Science Foundation’s definitions of R&D.</p>
       <p>Further, in our review of PSC codes we determined that basic, applied, and development phases were often used interchangeably with PSC sub codes and were applied inconsistently to awards. Due to these challenges with PSC accuracy and completeness, we’ve cited examples of these phases of research only in cases where we could independently verify the nature of the R&D work being performed.</p>
-      <p>To create the R&D as a Portion of Total Federal Contract Spending by Agency graph, we looked at the spending of the 24 <a href='https://cfo.gov/about/' rel='noreferrer noopener' target='_blank'>Chief Financial Officers Act agencies</a> and calculated the percentage of contract spending with appropriate R&D PSC codes of contract spending by each agency in FY 2019.</p>
+      <p>To create the R&D as a Portion of Total Federal Contract Spending by Agency graph, we looked at the spending of the 24 <a href='https://cfo.gov/about/' rel='noreferrer noopener' target='_blank'>Chief Financial Officers Act agencies</a> and calculated the percentage of contract spending with appropriate R&D PSC codes of contract spending by each agency in FY 2020.</p>
 
       <p>For the visualization of Categories of R&D Contract Spending, we used the same data pull from the first visualization and grouped spending into 20 categories using the PSC manual. The categories are:</p>
       <ul>
@@ -43,14 +43,14 @@ export default class RDHWCTA extends React.Component {
         <li>TRANSPORTATION (MODAL) R&D (AS)</li>
         <li>TRANSPORTATION (OTHER) R&D (AT)</li>
       </ul>
-      <p>The source data for the third visualization on Federal R&D obligations for 2009-2019 is from the National Center for Science and Engineering Statistics’ (NCSES) Survey of Federal Funds for Research and Development.  The survey data from NCSES is collected during an annual census of federal agencies. It is noted that the source for this visualization is different than the rest of the analysis to be able to show the larger trends in R&D funding that includes assistance funding.</p>
+      <p>The source data for the third visualization on Federal R&D obligations for 2010-2020 is from the National Center for Science and Engineering Statistics’ (NCSES) Survey of Federal Funds for Research and Development.  The survey data from NCSES is collected during an annual census of federal agencies. It is noted that the source for this visualization is different than the rest of the analysis to be able to show the larger trends in R&D funding that includes assistance funding.</p>
     </>
   }];
 
   notes = [{
     content: <>
       <p>Definitions for each of the types of R&D, including R&D Plant, can be found in the <a href='https://www.nsf.gov/statistics/fedfunds/glossary/def.htm' rel='noreferrer noopener' target='_blank'>Federal Funds Survey Glossary</a>.</p>
-      <p>The data reflects federal obligations through the end of Fiscal Year 2019.</p>
+      <p>The data reflects federal obligations through the end of Fiscal Year 2020.</p>
       <p>Please note that <a href='https://www.usaspending.gov/#/' rel='noreferrer noopener' target='_blank'>USAspending.gov</a> data is available to the public.</p>
     </>
   }];

--- a/src/pages/rd-in-contracting/methodologies.jsx
+++ b/src/pages/rd-in-contracting/methodologies.jsx
@@ -14,13 +14,25 @@ export default class RDHWCTA extends React.Component {
   title = 'Research & Development in Contract Spending';
   methodologies = [{
     content: <>
-      <p>We conducted this analysis using agency contract award data for Fiscal Year 2020, which agencies report to <a href='https://www.usaspending.gov/#/' rel='noreferrer noopener' target='_blank'>USAspending.gov</a>. Each reported contract includes information about the agency and sub-agency that awarded the contract, the amount obligated by the contract, and a Product and Service Code (PSC) that indicates the goods or services delivered as a result of the contract.</p>
-      <p>We excluded research and development (R&D) assistance funding such as grants, loans and scholarships in the first two sections of our analysis because, unlike PSCs, they are tracked using the Catalog of Federal Domestic Assistance (CFDA) codes. Since one CFDA listing can be used for a range of purposes, it is difficult to identify and verify funding devoted to R&D within a given CFDA.</p>
-      <p>For the category analysis, we classified R&D awards using the <a href='https://www.acquisition.gov/PSC_Manual' rel='noreferrer noopener' target='_blank'>General Services Administration’s PSC Manual</a>. We excluded contract spending designated with PSC codes that ended in 5 and 7, which represent Operational System Development (5) and Commercialization (7), since these codes fall outside of the National Science Foundation’s definitions of R&D.</p>
-      <p>Further, in our review of PSC codes we determined that basic, applied, and development phases were often used interchangeably with PSC sub codes and were applied inconsistently to awards. Due to these challenges with PSC accuracy and completeness, we’ve cited examples of these phases of research only in cases where we could independently verify the nature of the R&D work being performed.</p>
-      <p>To create the R&D as a Portion of Total Federal Contract Spending by Agency graph, we looked at the spending of the 24 <a href='https://cfo.gov/about/' rel='noreferrer noopener' target='_blank'>Chief Financial Officers Act agencies</a> and calculated the percentage of contract spending with appropriate R&D PSC codes of contract spending by each agency in FY 2020.</p>
-
-      <p>For the visualization of Categories of R&D Contract Spending, we used the same data pull from the first visualization and grouped spending into 20 categories using the PSC manual. The categories are:</p>
+      <p>
+        We conducted this analysis using agency contract award data for Fiscal Year 2020, which agencies report to <a href='https://www.usaspending.gov/#/' rel='noreferrer noopener' target='_blank'>USAspending.gov</a>. Each reported contract includes information about the agency and sub-agency that awarded the contract, the amount obligated by the contract, and a Product and Service Code (PSC) that indicates the goods or services delivered as a result of the contract.
+      </p>
+      <p>
+        We excluded R&D assistance funding such as grants, loans, and scholarships in the first two sections of our analysis because, unlike PSCs, they are tracked using the Catalog of Federal Domestic Assistance (CFDA) codes. Since one CFDA listing can be used for a range of purposes, it is difficult to identify and verify funding devoted to R&D within a given CFDA.
+      </p>
+      <p>
+        For the category analysis, we classified research and development (R&D) awards using the
+        <a href='https://www.acquisition.gov/PSC_Manual' rel='noreferrer noopener' target='_blank'>General Services Administration’s PSC Manual</a>. We excluded contract funding designated with PSC codes that ended in 5 and 7, which represent Operational System Development (5) and Commercialization (7), since these codes fall outside of the National Science Foundation’s definitions of R&D.
+      </p>
+      <p>
+        Further, in our review of PSC codes we determined that basic, applied, and development phases were often used interchangeably with PSC sub codes and were applied inconsistently to awards. Due to these challenges with PSC accuracy and completeness, we’ve cited examples of these phases of research only in cases where we could independently verify the nature of the R&D work being performed.
+      </p>
+      <p>
+        To create the R&D as a Portion of Total Federal Contract Funding by Agency graph, we looked at the funding of the 24  <a href='https://cfo.gov/about/' rel='noreferrer noopener' target='_blank'>Chief Financial Officers Act agencies</a> and calculated the percentage of contract funding with appropriate R&D PSC codes of contract funding by each agency in FY 2020.
+      </p>
+      <p>
+        For the visualization of Categories of R&D Contract Funding, we used the same data pull from the first visualization and grouped funding into 20 categories using the PSC manual. The categories are:
+      </p>
       <ul>
         <li>AGRICULTURE R&D (AA)</li>
         <li>COMMUNITY SERVICE R&D (AB)</li>
@@ -43,7 +55,9 @@ export default class RDHWCTA extends React.Component {
         <li>TRANSPORTATION (MODAL) R&D (AS)</li>
         <li>TRANSPORTATION (OTHER) R&D (AT)</li>
       </ul>
-      <p>The source data for the third visualization on Federal R&D obligations for 2010-2020 is from the National Center for Science and Engineering Statistics’ (NCSES) Survey of Federal Funds for Research and Development.  The survey data from NCSES is collected during an annual census of federal agencies. It is noted that the source for this visualization is different than the rest of the analysis to be able to show the larger trends in R&D funding that includes assistance funding.</p>
+      <p>
+        The source data for the fourth visualization on Federal R&D obligations for 2010-2020 is from the National Center for Science and Engineering Statistics’ (NCSES) Survey of Federal Funds for Research and Development. The survey data from NCSES is collected during an annual census of federal agencies. It is noted that the source for this visualization is different than the rest of the analysis to be able to show the larger trends in R&D funding that includes assistance funding.
+      </p>
     </>
   }];
 


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-8458

I didn't change the paths for the data downloads, because those files haven't been changed yet.

And the copy for the home page tile will be added when we add that tile to the home page.