### PR TITLE
8645 - added padding right and left to tablet size; changed left marg…

### DIFF
--- a/src/components/layouts/story/story.module.scss
+++ b/src/components/layouts/story/story.module.scss
@@ -82,6 +82,7 @@ h2 {
 @media (min-width: $tablet) and (max-width: $desktop - 1) {
   .story-page {
     max-width: $tablet-mcw;
+    padding: 0 40px;
   }
 }
 
@@ -94,6 +95,7 @@ h2 {
 @media (max-width: $tablet - 1) {
   .story-page {
     margin: 0 $margin-15 $margin-50;
+    padding: 0 40px;
   }
 
   .intro-sentence {

--- a/src/components/scrolling-circles/scrolling-circles.module.scss
+++ b/src/components/scrolling-circles/scrolling-circles.module.scss
@@ -69,7 +69,7 @@
 
 @media screen and (min-width: $tablet) {
   .main-container {
-    left: 40px;
+    left: 10px;
 
     .focused {
       box-shadow: 0 0 0 2px #888;
@@ -81,6 +81,14 @@
   .main-container {
     right: 0;
     width: 50px;
+
+    .section-container {
+      .circle {
+        height: 23px;
+        width: 23px;
+        font-size: 0.656rem;
+      }
+    }
 
     .label {
       right: 60px;

--- a/src/components/scrolling-circles/scrolling-circles.module.scss
+++ b/src/components/scrolling-circles/scrolling-circles.module.scss
@@ -80,7 +80,7 @@
 @media screen and (max-width: $tablet - 1) {
   .main-container {
     right: 0;
-    width: 50px;
+    width: 45px;
 
     .section-container {
       .circle {


### PR DESCRIPTION
…in for circles on tablet and desktop; changed size of circles to 23px and font size to 10.5px at mobile size

https://federal-spending-transparency.atlassian.net/browse/DA-8645

A couple of observations:
The circles seem really small at mobile size now, but maybe because I'm just used to the other size.
But if they are going to be this size I think we should move them up a little on the page (change main-container to top:80px, for tablet and mobile sizes) and at mobile only I think we should move them over a little to the right (main-container width:45px).