### PR TITLE
8695 - covid section 2 typo

### DIFF
--- a/src/page-sections/federal-covid-funding/overview/overview.jsx
+++ b/src/page-sections/federal-covid-funding/overview/overview.jsx
@@ -32,7 +32,7 @@ const Overview = props => {
 			<div className={overviewStyles.overviewNumber}>1</div>
 			<div className={overviewStyles.overviewSubtitle}>Appropriations</div>
 			<div className={overviewStyles.overviewText}>
-				After an appropriations law is passed, The Treasury issues funds to specific
+				After an appropriations law is passed, the Treasury issues funds to specific
 				agency spending accounts.
 			</div>
 		</Grid>


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DA-8695

