### PR TITLE
Remove duplicated section #3 from TOC

### DIFF
--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -277,28 +277,7 @@ export default class RdInContractingPage extends React.Component {
 			viztitle: '',
 			tagName: 'contracts',
 			readMoreOnMobile: true,
-			readMoreStyle: { color: globalStyles.rdBlue },
-		},
-		{
-			section: 'Contracts',
-			anchor: 'contracts',
-			number: '03',
-			subtext: 'Contracts',
-			subblurb: 'Top R&D Contracts',
-			comingSoon: true,
-			sectionTeaser: (
-				<>
-						<span className={styles.subtitleHighlight} key={'studies-teaser'}>
-							Top 5 R&D Contracts
-						</span>{' '}
-					by category in FY 2020
-				</>
-			),
-			introBlurb: this.getSecBlurbs()[2],
-			viztitle: '',
-			tagName: 'contracts',
-			readMoreOnMobile: true,
-			readMoreStyle: { color: globalStyles.rdBlue },
+			readMoreStyle: { color: globalStyles.rdMdBlue },
 		},
 		// {
 		// 	section: 'Studies',


### PR DESCRIPTION
No Ticket

ISSUE:  In QAT there are two section #3's in the TOC
![Screen Shot 2021-02-17 at 3 19 52 PM](https://user-images.githubusercontent.com/121010/108263196-ef7ab800-7133-11eb-88bd-43a7896062e0.png)


FIX:  Removed one 

![Screen Shot 2021-02-17 at 3 19 58 PM](https://user-images.githubusercontent.com/121010/108263177-e7bb1380-7133-11eb-84ab-17334d3f1217.png)

