### PR TITLE
Fixed check if target exists before it's observed

### DIFF
--- a/src/components/scrolling-circles/scrolling-circles.jsx
+++ b/src/components/scrolling-circles/scrolling-circles.jsx
@@ -68,7 +68,7 @@ const ScrollingCircles = ({ sections }) => {
 
 		sections.forEach(section => {
 			const target = document.getElementById(`section-${section.anchor}`);
-			if (typeof target === 'Element') {
+			if (target) {
 				observer.observe(target);
 			}
 		});


### PR DESCRIPTION
No ticket yet

The check if target exists (in DA-8678) broken the scrolling TOC circles in R&D

Please check scrolling TOC in COVID and R&D


https://user-images.githubusercontent.com/121010/108398931-8d7b8a80-71e7-11eb-81da-9011574a9b51.mov

