### PR TITLE
8731 rd footnotes spacing mobile

### DIFF
--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -343,7 +343,7 @@ export default class RdInContractingPage extends React.Component {
 				})}
 
 				<Grid container className={styles.footnotes}>
-					<Grid item xs={10}>
+					<Grid item xl={10}>
 						<Footnotes
 							footnotes={[
 								<>

--- a/src/pages/rd-in-contracting/rd-in-contracting.module.scss
+++ b/src/pages/rd-in-contracting/rd-in-contracting.module.scss
@@ -129,7 +129,7 @@ $bullet-size: 1.5rem;
   }
 }
 
-@media (max-width: $tablet - 1) {
+@media (max-width: $desktop - 1) {
   .footnotes {
     margin-top: 50px;
   }

--- a/src/pages/rd-in-contracting/rd-in-contracting.module.scss
+++ b/src/pages/rd-in-contracting/rd-in-contracting.module.scss
@@ -129,8 +129,8 @@ $bullet-size: 1.5rem;
   }
 }
 
-@media screen and (min-width: tablet - 1) {
+@media (max-width: $tablet - 1) {
   .footnotes {
-    justify-content: start;
+    margin-top: 50px;
   }
 }


### PR DESCRIPTION
…e grid element for the rd footnotes to xl so the text will be full width at phone and tablet sizes

https://federal-spending-transparency.atlassian.net/browse/DA-8731

The whitespace above the Footnotes component is handled differently in each of the instances of that component. To make them consistent would require changing the css for the StorySection and/or StorySectionHeading, which would affect several pages, as well as small tweaks to the css for each of the pages that already have the Footnotes component. So I just did the quick fix here.