### PR TITLE
No ticket yet - R&d copy updates

### DIFF
--- a/src/page-sections/rd-in-contracting/spending/spending-chart.jsx
+++ b/src/page-sections/rd-in-contracting/spending/spending-chart.jsx
@@ -102,8 +102,6 @@ export default class SpendingChart extends React.Component {
         USAID – US Agency for International Development
         DOI - Department of the Interior
         ED – Department of Education
-        DOC – Department of Commerce
-        VA – Department of Veterans’ Affairs
         `}
 			</div>
 		</AccordionList>

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -175,15 +175,15 @@ export default class RdInContractingPage extends React.Component {
 				COVID-19 R&D contract funding. COVID-19 R&D contract funding refers
 				specifically to contracts funded by the four supplemental appropriations
 				passed by congress to address the COVID-19 pandemic. For more information,
-				including legislation and funding details,{' '}
+				including legislation and funding details, visit our{' '}
 				<a
 					href="https://datalab.usaspending.gov/federal-covid-funding/"
 					rel="noreferrer noopener"
 					target="_blank"
 					className={styles.link}>
-					visit our Federal Response to COVID-19 analysis.
+					Federal Response to COVID-19
 				</a>
-				.
+				analysis.
 			</p>
 		</>,
 		<p>

--- a/src/pages/rd-in-contracting/index.jsx
+++ b/src/pages/rd-in-contracting/index.jsx
@@ -182,7 +182,7 @@ export default class RdInContractingPage extends React.Component {
 					target="_blank"
 					className={styles.link}>
 					Federal Response to COVID-19
-				</a>
+				</a>{' '}
 				analysis.
 			</p>
 		</>,

--- a/src/pages/rd-in-contracting/methodologies.jsx
+++ b/src/pages/rd-in-contracting/methodologies.jsx
@@ -47,10 +47,17 @@ export default class RDHWCTA extends React.Component {
 							target="_blank">
 							General Services Administration’s (GSA) PSC Manual
 						</a>{' '}
-						for all CFO Act agencies. We excluded contract funding designated with PSC
-						codes that ended in 5 and 7, which represent Operational System
-						Development (5) and Commercialization (7), since these codes fall outside
-						of the Office of Management and Budget (OMB) definitions of R&D (see{' '}
+						for all{' '}
+						<a
+							href="https://cfo.gov/about/"
+							rel="noreferrer noopener"
+							target="_blank">
+							CFO Act agencies
+						</a>
+						. We excluded contract funding designated with PSC codes that ended in 5
+						and 7, which represent Operational System Development (5) and
+						Commercialization (7), since these codes fall outside of the Office of
+						Management and Budget (OMB) definitions of R&D (see{' '}
 						<a
 							href="https://www.whitehouse.gov/wp-content/uploads/2018/06/s84.pdf"
 							rel="noreferrer noopener"

--- a/src/pages/rd-in-contracting/methodologies.jsx
+++ b/src/pages/rd-in-contracting/methodologies.jsx
@@ -50,15 +50,20 @@ export default class RDHWCTA extends React.Component {
 						for all CFO Act agencies. We excluded contract funding designated with PSC
 						codes that ended in 5 and 7, which represent Operational System
 						Development (5) and Commercialization (7), since these codes fall outside
-						of the Office of Management and Budget (OMB) definitions of R&D (see OMB
-						Circular A-11, Schedule C, Section 84.2(c)). As such, we refer to R&D
-						contract funding as limited to this group of contract transactions
-						throughout this analysis. The COVID-19 Funding versions of each
-						visualization were generated using the same subset of R&D, limiting the
-						contract transactions included to those funded using funding specifically
-						appropriated to address the COVID-19 pandemic. Contract transactions
-						funded by COVID-19 appropriations can be tracked using the Disaster
-						Emergency Fund Code (DEFC).
+						of the Office of Management and Budget (OMB) definitions of R&D (see{' '}
+						<a
+							href="https://www.whitehouse.gov/wp-content/uploads/2018/06/s84.pdf"
+							rel="noreferrer noopener"
+							target="_blank">
+							OMB Circular A-11, Schedule C, Section 84.2(c)
+						</a>
+						). As such, we refer to R&D contract funding as limited to this group of
+						contract transactions throughout this analysis. The COVID-19 Funding
+						versions of each visualization were generated using the same subset of
+						R&D, limiting the contract transactions included to those funded using
+						funding specifically appropriated to address the COVID-19 pandemic.
+						Contract transactions funded by COVID-19 appropriations can be tracked
+						using the Disaster Emergency Fund Code (DEFC).
 					</p>
 					<p>
 						To create the R&D as a Portion of Total Federal Contract Funding by Agency


### PR DESCRIPTION
See Slack #dl-rd channel for defects reported by Allie Wallis (items are listed below).  PR contains fixes for items that require code changes (ie. #1, 2, 3, and 5)
https://data-transparency-bfs.slack.com/archives/CJAD4HQBC/p1615409400017900

1. Section 1, last sentence of first paragraph: looks like there is an extra period at the end of the sentence. Quick defect sub-task to fix?
2. Same section, same line, in the MAC, we do not include "analysis" in the hyperlink. Should we just adjust the MAC to reflect QAT?
3. Section 1 Instructions: DOC and VA are listed under Label Definitions in QAT but not in the MAC. Same scenario here, just update MAC? 
4. In the MAC under Viz 2 Instructions Accordion, just need a period added to the end of first bullet point. (Correct in QAT) (not a code change)
5. In the DSM section: there are two instances in the MAC (second paragraph) where we have copy hyperlinked but it is not in QAT. Should we link these on the site?  CFO Act agencies, OMB Circular A-11, Schedule C, Section 84.2 (c))